### PR TITLE
Add code docs

### DIFF
--- a/atprotolib-rs/Cargo.toml
+++ b/atprotolib-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "atprotolib-rs"
 version = "0.1.0"
 edition = "2021"
+description = "A Rust library for various ATProtocol (Used by BlueSky) API/Lexicon types."
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/atprotolib-rs/Cargo.toml
+++ b/atprotolib-rs/Cargo.toml
@@ -15,3 +15,6 @@ reqwest = { version = "0.12.9", features = ["json"], optional = true}
 
 [features]
 apicalls = ["dep:reqwest"]
+
+[lints.rust]
+missing_docs = "warn"

--- a/atprotolib-rs/src/api_calls.rs
+++ b/atprotolib-rs/src/api_calls.rs
@@ -1,30 +1,50 @@
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 
+/// Represents API authentication configuration.
 #[derive(Clone)]
 pub struct ApiAuthConfig {
+    /// The data for the API authentication configuration.
     pub data: ApiAuthConfigData
 }
 
+/// Represents the data for API authentication configuration.
 #[derive(Clone)]
 pub enum ApiAuthConfigData {
+    /// No authentication.
     None,
+
+    /// Admin user authentication.
     AdminUser(ApiAuthAdminUser),
+
+    /// Bearer token authentication.
     BearerToken(ApiAuthBearerToken)
 }
 
+/// Represents an admin user for API authentication.
 #[derive(Clone)]
 pub struct ApiAuthAdminUser {
+    /// The username of the admin user.
     pub username: String,
+
+    /// The password of the admin user.
     pub password: String
 }
 
+/// Represents a bearer token for API authentication.
 #[derive(Clone)]
 pub struct ApiAuthBearerToken {
+    /// The bearer token.
     pub token: String
 }
 
+/// A trait to add ATProto API authentication to a `RequestBuilder` instance from `reqwest`.
 pub trait AddApiAuth {
+    /// Adds ATProto API authentication to a `RequestBuilder` instance.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `api_auth_config` - The API authentication configuration.
     fn add_api_auth(
         self,
         api_auth_config: ApiAuthConfig
@@ -32,33 +52,52 @@ pub trait AddApiAuth {
 }
 
 impl AddApiAuth for RequestBuilder {
+    /// Adds ATProto API authentication to a `RequestBuilder` instance.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `api_auth_config` - The API authentication configuration.
     fn add_api_auth(
         self,
         api_auth_config: ApiAuthConfig
     ) -> Self {
         match api_auth_config.data {
+            // The API authentication configuration is for an admin user.
             ApiAuthConfigData::AdminUser(auth) => {
                 self.basic_auth(auth.username, Some(auth.password))
             }
 
+            // The API authentication configuration is for a bearer token.
             ApiAuthConfigData::BearerToken(auth) => self.bearer_auth(auth.token),
 
+            // The API authentication configuration is for no authentication.
             ApiAuthConfigData::None => self
         }
     }
 }
 
+/// Represents an API error.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiError {
+    /// The returned error code.
     #[serde(rename = "error")]
     pub error: String,
+
+    /// The returned error message.
     #[serde(rename = "message")]
     pub message: String,
+
+    /// The kind of API error. Typically corresponds to the HTTP status code.
     #[serde(skip, default)]
     pub kind: ApiErrorKind
 }
 
 impl ApiError {
+    /// Creates a new `ApiError` instance from a `Response`.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `response` - The `Response` instance.
     pub async fn new(response: Response) -> Result<Self, Box<dyn std::error::Error>> {
         let status = response.status();
         let text = response.text().await?;
@@ -96,17 +135,37 @@ impl std::fmt::Display for ApiError {
     }
 }
 
+/// Represents the kind of an API error.
 #[derive(Debug, Clone)]
 pub enum ApiErrorKind {
+    /// An unknown API error.
     Unknown,
+
+    /// A bad request API error.
     BadRequest,
+
+    /// An unauthorized API error.
     Unauthorized,
+
+    /// A forbidden API error.
     Forbidden,
+
+    /// A not found API error.
     NotFound,
+
+    /// A method not allowed API error.
     MethodNotAllowed,
+
+    /// A conflict API error.
     Conflict,
+
+    /// An internal server error API error.
     InternalServerError,
+
+    /// A service unavailable API error.
     ServiceUnavailable,
+
+    /// A gateway timeout API error.
     GatewayTimeout
 }
 

--- a/atprotolib-rs/src/lib.rs
+++ b/atprotolib-rs/src/lib.rs
@@ -1,3 +1,5 @@
+//! This crate provides a library of types and functions to interact with the ATProtocol.
+
 /// Contains types related to the ATProtocol.
 pub mod types;
 

--- a/atprotolib-rs/src/lib.rs
+++ b/atprotolib-rs/src/lib.rs
@@ -1,4 +1,6 @@
+/// Contains types related to the ATProtocol.
 pub mod types;
 
 #[cfg(feature = "apicalls")]
+/// Contains structs and functions to help with making API calls
 pub mod api_calls;

--- a/atprotolib-rs/src/types/app_bsky/actor/api_calls.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/api_calls.rs
@@ -3,6 +3,15 @@ use crate::{
     types::app_bsky
 };
 
+/// Get a detailed profile view of an actor. Does not require auth, but contains relevant metadata with auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the profile of.
 pub async fn get_profile(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -30,6 +39,16 @@ pub async fn get_profile(
     }
 }
 
+/// Get a list of suggested actors. Expected use is discovery of accounts to follow during new account onboarding.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of actors to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_suggestions(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -65,6 +84,16 @@ pub async fn get_suggestions(
     }
 }
 
+/// Find actor suggestions for a prefix search term. Expected use is for auto-completion during text field entry. Does not require auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `query` - The search term to find actors for.
+/// * `limit` - The maximum number of actors to return. Defaults to 10.
 pub async fn search_actors_typeahead(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -101,6 +130,17 @@ pub async fn search_actors_typeahead(
     }
 }
 
+/// Find actors (profiles) matching search criteria. Does not require auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `query` - The search term to find actors for.
+/// * `limit` - The maximum number of actors to return. Defaults to 25.
+/// * `cursor` - A cursor for pagination.
 pub async fn search_actors(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/app_bsky/actor/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/defs.rs
@@ -6,177 +6,186 @@ use crate::types::{
     com_atproto::label::Label
 };
 
-/*    Type: profileViewBasic
-    Id: app.bsky.actor.defs#profileViewBasic
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - handle: string (JsonProperty: handle) [Required]
-    - display_name: string (JsonProperty: displayName) [Optional]
-    - avatar: string (JsonProperty: avatar) [Optional]
-    - associated: #profileAssociated (JsonProperty: associated) [Optional]
-    - viewer: #viewerState (JsonProperty: viewer) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - created_at: datetime (JsonProperty: createdAt) [Optional]
-*/
+/// A view of a profile with basic information.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#profileViewBasic")]
 pub struct ProfileViewBasic {
+    /// The DID of the profile.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The handle of the profile.
     #[serde(rename = "handle")]
     pub handle: String,
+
+    /// The display name of the profile.
     #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// The avatar of the profile.
     #[serde(rename = "avatar", skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
+
+    /// Profiles associated with this profile.
     #[serde(rename = "associated", skip_serializing_if = "Option::is_none")]
     pub associated: Option<ProfileAssociated>,
+
+    /// The state of the profile relative to the viewer.
     #[serde(rename = "viewer", skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
+
+    /// Labels associated with the profile.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
+
+    /// The date and time the profile was created.
     #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>
 }
 
-/*    Type: profileView
-    Id: app.bsky.actor.defs#profileView
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - handle: string (JsonProperty: handle) [Required]
-    - display_name: string (JsonProperty: displayName) [Optional]
-    - description: string (JsonProperty: description) [Optional]
-    - avatar: string (JsonProperty: avatar) [Optional]
-    - associated: #profileAssociated (JsonProperty: associated) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Optional]
-    - created_at: datetime (JsonProperty: createdAt) [Optional]
-    - viewer: #viewerState (JsonProperty: viewer) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-*/
+/// A view of a profile.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#profileView")]
 pub struct ProfileView {
+    /// The DID of the profile.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The handle of the profile.
     #[serde(rename = "handle")]
     pub handle: String,
+
+    /// The display name of the profile.
     #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// The description of the profile.
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// The avatar of the profile.
     #[serde(rename = "avatar", skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
+
+    /// Profiles associated with this profile.
     #[serde(rename = "associated", skip_serializing_if = "Option::is_none")]
     pub associated: Option<ProfileAssociated>,
+
+    /// The date and time the profile was indexed.
     #[serde(rename = "indexedAt", skip_serializing_if = "Option::is_none")]
     pub indexed_at: Option<DateTime<Utc>>,
+
+    /// The date and time the profile was created.
     #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
+
+    /// The state of the profile relative to the viewer.
     #[serde(rename = "viewer", skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
+
+    /// Labels associated with the profile.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>
 }
 
-/*    Type: profileViewDetailed
-    Id: app.bsky.actor.defs#profileViewDetailed
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - handle: string (JsonProperty: handle) [Required]
-    - display_name: string (JsonProperty: displayName) [Optional]
-    - description: string (JsonProperty: description) [Optional]
-    - avatar: string (JsonProperty: avatar) [Optional]
-    - banner: string (JsonProperty: banner) [Optional]
-    - followers_count: integer  (JsonProperty: followersCount) [Optional]
-    - follows_count: integer  (JsonProperty: followsCount) [Optional]
-    - posts_count: integer  (JsonProperty: postsCount) [Optional]
-    - associated: #profileAssociated (JsonProperty: associated) [Optional]
-    - joined_via_starter_pack: app.bsky.graph.defs#starterPackViewBasic (JsonProperty: joinedViaStarterPack) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Optional]
-    - created_at: datetime (JsonProperty: createdAt) [Optional]
-    - viewer: #viewerState (JsonProperty: viewer) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - pinned_post: com.atproto.repo.strongRef (JsonProperty: pinnedPost) [Optional]
-*/
+/// A detailed view of a profile.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#profileViewDetailed")]
 pub struct ProfileViewDetailed {
+    /// The DID of the profile.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The handle of the profile.
     #[serde(rename = "handle")]
     pub handle: String,
+
+    /// The display name of the profile.
     #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
+    /// The description of the profile.
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// The avatar of the profile.
     #[serde(rename = "avatar", skip_serializing_if = "Option::is_none")]
     pub avatar: Option<String>,
+
+    /// The banner of the profile.
     #[serde(rename = "banner", skip_serializing_if = "Option::is_none")]
     pub banner: Option<String>,
+
+    /// The number of followers of the profile.
     #[serde(rename = "followersCount", default)]
     pub followers_count: i32,
+
+    /// The number of profiles the profile follows.
     #[serde(rename = "followsCount", default)]
     pub follows_count: i32,
+
+    /// The number of posts the profile has made.
     #[serde(rename = "postsCount", default)]
     pub posts_count: i32,
+
+    /// Profiles associated with this profile.
     #[serde(rename = "associated", skip_serializing_if = "Option::is_none")]
     pub associated: Option<ProfileAssociated>,
+
+    /// Data regarding the starter pack the profile joined via.
     #[serde(
         rename = "joinedViaStarterPack",
         skip_serializing_if = "Option::is_none"
     )]
     pub joined_via_starter_pack: Option<StarterPackViewBasic>,
+
+    /// The date and time the profile was indexed.
     #[serde(rename = "indexedAt", skip_serializing_if = "Option::is_none")]
     pub indexed_at: Option<DateTime<Utc>>,
+
+    /// The date and time the profile was created.
     #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
+
+    /// The state of the profile relative to the viewer.
     #[serde(rename = "viewer", skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
+
+    /// Labels associated with the profile.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
+
+    /// The pinned post of the profile.
     #[serde(rename = "pinnedPost", skip_serializing_if = "Option::is_none")]
     pub pinned_post: Option<String>
 }
 
-/*    Type: profileAssociated
-    Id: app.bsky.actor.defs#profileAssociated
-    Kind: object
-
-    Properties:
-    - lists: integer  (JsonProperty: lists) [Optional]
-    - feedgens: integer  (JsonProperty: feedgens) [Optional]
-    - starter_packs: integer  (JsonProperty: starterPacks) [Optional]
-    - labeler: boolean  (JsonProperty: labeler) [Optional]
-    - chat: #profileAssociatedChat (JsonProperty: chat) [Optional]
-*/
+/// Data regarding a profile associated with a profile.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#profileAssociated")]
 pub struct ProfileAssociated {
+    /// The number of lists the profile is associated with.
     #[serde(rename = "lists", default)]
     pub lists: i32,
+
+    /// The number of feed generators the profile is associated with.
     #[serde(rename = "feedgens", default)]
     pub feedgens: i32,
+
+    /// The number of starter packs the profile is associated with.
     #[serde(rename = "starterPacks", default)]
     pub starter_packs: i32,
+
+    /// The number of labelers the profile is associated with.
     #[serde(rename = "labeler", default)]
     pub labeler: bool,
+
+    /// Information regarding chats associated with the profile.
     #[serde(rename = "chat", skip_serializing_if = "Option::is_none")]
     pub chat: Option<ProfileAssociatedChat>
 }
 
-/*    Type: profileAssociatedChat
-    Id: app.bsky.actor.defs#profileAssociatedChat
-    Kind: object
-
-    Properties:
-    - allow_incoming: string (JsonProperty: allowIncoming) [Required]
-*/
+/// Contains information regarding chats associated with a profile.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#profileAssociatedChat")]
 pub struct ProfileAssociatedChat {
@@ -184,64 +193,57 @@ pub struct ProfileAssociatedChat {
     pub allow_incoming: String
 }
 
-/*    Type: viewerState
-    Id: app.bsky.actor.defs#viewerState
-    Kind: object
-
-    Properties:
-    - muted: boolean  (JsonProperty: muted) [Optional]
-    - muted_by_list: app.bsky.graph.defs#listViewBasic (JsonProperty: mutedByList) [Optional]
-    - blocked_by: boolean  (JsonProperty: blockedBy) [Optional]
-    - blocking: string (JsonProperty: blocking) [Optional]
-    - blocking_by_list: app.bsky.graph.defs#listViewBasic (JsonProperty: blockingByList) [Optional]
-    - following: string (JsonProperty: following) [Optional]
-    - followed_by: string (JsonProperty: followedBy) [Optional]
-    - known_followers: #knownFollowers (JsonProperty: knownFollowers) [Optional]
-*/
+/// Represents the state of profile relative to the viewer.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#viewerState")]
 pub struct ViewerState {
+    /// Whether the profile is muted.
     #[serde(rename = "muted", default)]
     pub muted: bool,
+
+    /// Whether the profile is muted by a list.
     #[serde(rename = "mutedByList", skip_serializing_if = "Option::is_none")]
     pub muted_by_list: Option<ListViewBasic>,
+
+    /// Whether the profile is blocked by the viewer. (?)
     #[serde(rename = "blockedBy", default)]
     pub blocked_by: bool,
+
+    /// The ATProtocol URI of the block.
     #[serde(rename = "blocking")]
     pub blocking: String,
+
+    /// Lists the profile is blocked by.
     #[serde(rename = "blockingByList", skip_serializing_if = "Option::is_none")]
     pub blocking_by_list: Option<ListViewBasic>,
+
+    /// The ATProtocol URI of the follow.
     #[serde(rename = "following")]
     pub following: String,
+
+    /// The ATProtocol URI for followed by. (?)
     #[serde(rename = "followedBy")]
     pub followed_by: String,
+
+    /// Followers of the profile known to the viewer.
     #[serde(rename = "knownFollowers", skip_serializing_if = "Option::is_none")]
     pub known_followers: Option<KnownFollowers>
 }
 
-/*    Type: knownFollowers
-    Id: app.bsky.actor.defs#knownFollowers
-    Kind: object
-
-    Properties:
-    - count: integer  (JsonProperty: count) [Required]
-    - followers: #profileViewBasic[] (JsonProperty: followers) [Required]
-*/
+/// Represents followers of a profile known to the viewer.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#knownFollowers")]
 pub struct KnownFollowers {
+    /// The number of known followers.
     #[serde(rename = "count", default)]
     pub count: i32,
+
+    /// Basic profile views of known followers.
     #[serde(rename = "followers")]
     pub followers: Vec<ProfileViewBasic>
 }
 
-/*    Type: preferences
-    Id: app.bsky.actor.defs#preferences
-    Kind: array union
-
-    Properties:
-*/
+/// Represents a profile's preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#preferences")]
 pub struct Preferences {
@@ -265,249 +267,195 @@ pub enum PreferencesEnum {
     BskyAppStatePref(BskyAppStatePref)
 }
 
-/*    Type: adultContentPref
-    Id: app.bsky.actor.defs#adultContentPref
-    Kind: object
-
-    Properties:
-    - enabled: boolean  (JsonProperty: enabled) [Required]
-*/
+/// Represents adult content preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#adultContentPref")]
 pub struct AdultContentPref {
+    /// Whether adult content is enabled.
     #[serde(rename = "enabled", default)]
     pub enabled: bool
 }
 
-/*    Type: contentLabelPref
-    Id: app.bsky.actor.defs#contentLabelPref
-    Kind: object
-
-    Properties:
-    - labeler_did: string (JsonProperty: labelerDid) [Optional]
-    - label: string (JsonProperty: label) [Required]
-    - visibility: string (JsonProperty: visibility) [Required]
-*/
+/// Represents content label preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#contentLabelPref")]
 pub struct ContentLabelPref {
+    /// The DID of the labeler.
     #[serde(rename = "labelerDid", skip_serializing_if = "Option::is_none")]
     pub labeler_did: Option<String>,
+
+    /// The name of the label.
     #[serde(rename = "label")]
     pub label: String,
+
+    /// The visibility of the label.
     #[serde(rename = "visibility")]
     pub visibility: String
 }
 
-/*    Type: savedFeed
-    Id: app.bsky.actor.defs#savedFeed
-    Kind: object
-
-    Properties:
-    - id: string (JsonProperty: id) [Required]
-    - type: string (JsonProperty: type) [Required]
-    - value: string (JsonProperty: value) [Required]
-    - pinned: boolean  (JsonProperty: pinned) [Required]
-*/
+/// Represents a saved feed.
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type", rename = "feed")]
 pub struct SavedFeed {
+    /// The ID of the saved feed.
     #[serde(rename = "id")]
     pub id: String,
+
+    /// The type of the saved feed.
     #[serde(rename = "type")]
     pub type_: String,
+
+    /// The value of the saved feed.
     #[serde(rename = "value")]
     pub value: String,
+
+    /// Whether the saved feed is pinned.
     #[serde(rename = "pinned", default)]
     pub pinned: bool
 }
 
-/*    Type: savedFeedsPrefV2
-    Id: app.bsky.actor.defs#savedFeedsPrefV2
-    Kind: object
-
-    Properties:
-    - items: app.bsky.actor.defs#savedFeed[] (JsonProperty: items) [Required]
-*/
+/// Represents saved feeds preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#savedFeedsPrefV2")]
 pub struct SavedFeedsPrefV2 {
+    /// A list of saved feeds.
     #[serde(rename = "items")]
     pub items: Vec<SavedFeed>
 }
 
-/*    Type: savedFeedsPref
-    Id: app.bsky.actor.defs#savedFeedsPref
-    Kind: object
-
-    Properties:
-    - pinned: string[] (JsonProperty: pinned) [Required]
-    - saved: string[] (JsonProperty: saved) [Required]
-    - timeline_index: integer  (JsonProperty: timelineIndex) [Optional]
-*/
+/// Represents saved feeds preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#savedFeedsPref")]
 pub struct SavedFeedsPref {
+    /// A list of pinned saved feeds.
     #[serde(rename = "pinned")]
     pub pinned: Vec<String>,
+
+    /// A list of saved feeds.
     #[serde(rename = "saved")]
     pub saved: Vec<String>,
+
+    /// The index of the timeline.
     #[serde(rename = "timelineIndex", default)]
     pub timeline_index: i32
 }
 
-/*    Type: personalDetailsPref
-    Id: app.bsky.actor.defs#personalDetailsPref
-    Kind: object
-
-    Properties:
-    - birth_date: datetime (JsonProperty: birthDate) [Optional]
-*/
+/// Represents personal details preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#personalDetailsPref")]
 pub struct PersonalDetailsPref {
+    /// The user's birth date.
     #[serde(rename = "birthDate", skip_serializing_if = "Option::is_none")]
     pub birth_date: Option<DateTime<Utc>>
 }
 
-/*    Type: feedViewPref
-    Id: app.bsky.actor.defs#feedViewPref
-    Kind: object
-
-    Properties:
-    - feed: string (JsonProperty: feed) [Required]
-    - hide_replies: boolean  (JsonProperty: hideReplies) [Optional]
-    - hide_replies_by_unfollowed: boolean  (JsonProperty: hideRepliesByUnfollowed) [Optional]
-    - hide_replies_by_like_count: integer  (JsonProperty: hideRepliesByLikeCount) [Optional]
-    - hide_reposts: boolean  (JsonProperty: hideReposts) [Optional]
-    - hide_quote_posts: boolean  (JsonProperty: hideQuotePosts) [Optional]
-*/
+/// Represents feed view preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#feedViewPref")]
 pub struct FeedViewPref {
+    /// The URI of the feed.
     #[serde(rename = "feed")]
     pub feed: String,
+
+    /// Whether replies are hidden.
     #[serde(rename = "hideReplies", default)]
     pub hide_replies: bool,
+
+    /// Whether replies by unfollowed users are hidden.
     #[serde(rename = "hideRepliesByUnfollowed", default)]
     pub hide_replies_by_unfollowed: bool,
+
+    /// How many likes are required for a reply to show in the feed.
     #[serde(rename = "hideRepliesByLikeCount", default)]
     pub hide_replies_by_like_count: i32,
+
+    /// Whether reposts are hidden.
     #[serde(rename = "hideReposts", default)]
     pub hide_reposts: bool,
+
+    /// Whether quote posts are hidden.
     #[serde(rename = "hideQuotePosts", default)]
     pub hide_quote_posts: bool
 }
 
-/*    Type: threadViewPref
-    Id: app.bsky.actor.defs#threadViewPref
-    Kind: object
-
-    Properties:
-    - sort: string (JsonProperty: sort) [Optional]
-    - prioritize_followed_users: boolean  (JsonProperty: prioritizeFollowedUsers) [Optional]
-*/
+/// Represents thread view preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#threadViewPref")]
 pub struct ThreadViewPref {
+    /// The sorting mode for threads.
     #[serde(rename = "sort", skip_serializing_if = "Option::is_none")]
     pub sort: Option<String>,
+
+    /// Whether to prioritize followed users.
     #[serde(rename = "prioritizeFollowedUsers", default)]
     pub prioritize_followed_users: bool
 }
 
-/*    Type: interestsPref
-    Id: app.bsky.actor.defs#interestsPref
-    Kind: object
-
-    Properties:
-    - tags: string[] (JsonProperty: tags) [Required]
-*/
+/// Represents interests preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#interestsPref")]
 pub struct InterestsPref {
+    /// A list of tags which describe the account owner's interests gathered during onboarding.
     #[serde(rename = "tags")]
     pub tags: Vec<String>
 }
 
-/*    Type: mutedWord
-    Id: app.bsky.actor.defs#mutedWord
-    Kind: object
-
-    Properties:
-    - id: string (JsonProperty: id) [Optional]
-    - value: string (JsonProperty: value) [Required]
-    - targets: app.bsky.actor.defs#mutedWordTarget[] (JsonProperty: targets) [Required]
-    - actor_target: string (JsonProperty: actorTarget) [Optional]
-    - expires_at: datetime (JsonProperty: expiresAt) [Optional]
-*/
+/// Represents a muted word.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#mutedWord")]
 pub struct MutedWord {
+    /// The ID of the muted word.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+
+    /// The value of the muted word.
     #[serde(rename = "value")]
     pub value: String,
+
+    /// The targets of the muted word.
     #[serde(rename = "targets")]
     pub targets: Vec<String>,
+
+    /// Groups of users to apply the muted word to. If undefined, applies to all users.
     #[serde(rename = "actorTarget", skip_serializing_if = "Option::is_none")]
     pub actor_target: Option<String>,
+
+    /// The date and time the muted word expires.
     #[serde(rename = "expiresAt", skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<DateTime<Utc>>
 }
 
-/*    Type: mutedWordsPref
-    Id: app.bsky.actor.defs#mutedWordsPref
-    Kind: object
-
-    Properties:
-    - items: app.bsky.actor.defs#mutedWord[] (JsonProperty: items) [Required]
-*/
+/// Represents muted words preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#mutedWordsPref")]
 pub struct MutedWordsPref {
+    /// A list of muted words.
     #[serde(rename = "items")]
     pub items: Vec<MutedWord>
 }
 
-/*    Type: hiddenPostsPref
-    Id: app.bsky.actor.defs#hiddenPostsPref
-    Kind: object
-
-    Properties:
-    - items: string[] (JsonProperty: items) [Required]
-*/
+/// Represents hidden posts preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#hiddenPostsPref")]
 pub struct HiddenPostsPref {
+    /// A list of URIs of hidden posts by the user.
     #[serde(rename = "items")]
     pub items: Vec<String>
 }
 
-/*    Type: labelersPref
-    Id: app.bsky.actor.defs#labelersPref
-    Kind: object
-
-    Properties:
-    - labelers: #labelerPrefItem[] (JsonProperty: labelers) [Required]
-*/
+/// Represents labelers preferences.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#labelersPref")]
 pub struct LabelersPref {
+    /// A list of labeler preferences.
     #[serde(rename = "labelers")]
     pub labelers: Vec<LabelerPrefItem>
 }
 
-/*    Type: labelerPrefItem
-    Id: app.bsky.actor.defs#labelerPrefItem
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-*/
+/// A labeler preference item.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.actor.defs#labelerPrefItem")]
 pub struct LabelerPrefItem {
+    /// The DID of the labeler.
     #[serde(rename = "did")]
     pub did: String
 }

--- a/atprotolib-rs/src/types/app_bsky/actor/get_profiles.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/get_profiles.rs
@@ -6,15 +6,10 @@ use super::ProfileViewDetailed;
     app.bsky.actor.getProfiles
 */
 
-/*    Type: response
-    Id: app.bsky.actor.getProfiles#response
-    Kind: object
-
-    Properties:
-    - profiles: app.bsky.actor.defs#profileViewDetailed[] (JsonProperty: profiles) [Required]
-*/
+/// A response to getting multiple profiles.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetProfilesResponse {
+    /// A list of profiles.
     #[serde(rename = "profiles")]
     pub profiles: Vec<ProfileViewDetailed>
 }

--- a/atprotolib-rs/src/types/app_bsky/actor/get_suggestions.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/get_suggestions.rs
@@ -6,18 +6,14 @@ use super::ProfileView;
     app.bsky.actor.getSuggestions
 */
 
-/*    Type: response
-    Id: app.bsky.actor.getSuggestions#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - actors: app.bsky.actor.defs#profileView[] (JsonProperty: actors) [Required]
-*/
+/// A response to getting suggested actors.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetSuggestionsResponse {
+    /// A cursor for the stream.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// A list of actors.
     #[serde(rename = "actors")]
     pub actors: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/actor/search_actors.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/search_actors.rs
@@ -6,18 +6,14 @@ use super::ProfileView;
     app.bsky.actor.searchActors
 */
 
-/*    Type: response
-    Id: app.bsky.actor.searchActors#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - actors: app.bsky.actor.defs#profileView[] (JsonProperty: actors) [Required]
-*/
+/// A response to searching for actors.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SearchActorsResponse {
+    /// A cursor for the stream.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// A list of actors.
     #[serde(rename = "actors")]
     pub actors: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/actor/search_actors_typeahead.rs
+++ b/atprotolib-rs/src/types/app_bsky/actor/search_actors_typeahead.rs
@@ -6,15 +6,10 @@ use super::ProfileViewBasic;
     app.bsky.actor.searchActorsTypeahead
 */
 
-/*    Type: response
-    Id: app.bsky.actor.searchActorsTypeahead#response
-    Kind: object
-
-    Properties:
-    - actors: app.bsky.actor.defs#profileViewBasic[] (JsonProperty: actors) [Required]
-*/
+/// A response for the typeahead search for actors.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SearchActorsTypeaheadResponse {
+    /// A list of actors.
     #[serde(rename = "actors")]
     pub actors: Vec<ProfileViewBasic>
 }

--- a/atprotolib-rs/src/types/app_bsky/embed/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/embed/defs.rs
@@ -1,18 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-/*    Type: aspectRatio
-    Id: app.bsky.embed.defs#aspectRatio
-    Kind: object
-
-    Properties:
-    - width: integer  (JsonProperty: width) [Required]
-    - height: integer  (JsonProperty: height) [Required]
-*/
+/// Represents the aspect ratio of an embed.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.defs#aspectRatio")]
 pub struct AspectRatio {
+    /// The width of the embed.
     #[serde(rename = "width", default)]
     pub width: i32,
+
+    /// The height of the embed.
     #[serde(rename = "height", default)]
     pub height: i32
 }

--- a/atprotolib-rs/src/types/app_bsky/embed/external.rs
+++ b/atprotolib-rs/src/types/app_bsky/embed/external.rs
@@ -4,59 +4,50 @@ use serde::{Deserialize, Serialize};
     app.bsky.embed.external
 */
 
-/*    Type: external
-    Id: app.bsky.embed.external#external
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - title: string (JsonProperty: title) [Required]
-    - description: string (JsonProperty: description) [Required]
-    - thumb: blob  (JsonProperty: thumb) [Optional]
-*/
+/// A representation of some externally linked content (eg, a URL and 'card'), embedded in a Bluesky record (eg, a post).
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExternalEmbed {
+    /// The URI of the external content.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The title of the external content.
     #[serde(rename = "title")]
     pub title: String,
+
+    /// A description of the external content.
     #[serde(rename = "description")]
     pub description: String,
+
+    /// A thumbnail image representing the external content.
     #[serde(rename = "thumb", skip_serializing_if = "Option::is_none")]
     pub thumb: Option<Vec<u8>>
 }
 
-/*    Type: view
-    Id: app.bsky.embed.external#view
-    Kind: object
-
-    Properties:
-    - external: #viewExternal (JsonProperty: external) [Required]
-*/
+/// A view of an external embed.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExternalEmbedView {
+    /// The external embed.
     #[serde(rename = "external")]
     pub external: ExternalEmbed
 }
 
-/*    Type: viewExternal
-    Id: app.bsky.embed.external#viewExternal
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - title: string (JsonProperty: title) [Required]
-    - description: string (JsonProperty: description) [Required]
-    - thumb: string (JsonProperty: thumb) [Optional]
-*/
+/// A view of an external embed, with the external embed itself embedded. (?)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExternalEmbedViewExternal {
+    /// The URI of the external content.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The title of the external content.
     #[serde(rename = "title")]
     pub title: String,
+
+    /// A description of the external content.
     #[serde(rename = "description")]
     pub description: String,
+
+    /// A URI to a thumbnail image representing the external content.
     #[serde(rename = "thumb", skip_serializing_if = "Option::is_none")]
     pub thumb: Option<String>
 }

--- a/atprotolib-rs/src/types/app_bsky/embed/images.rs
+++ b/atprotolib-rs/src/types/app_bsky/embed/images.rs
@@ -6,56 +6,49 @@ use super::AspectRatio;
     app.bsky.embed.images
 */
 
-/*    Type: image
-    Id: app.bsky.embed.images#image
-    Kind: object
-
-    Properties:
-    - image: blob  (JsonProperty: image) [Required]
-    - alt: string (JsonProperty: alt) [Required]
-    - aspect_ratio: app.bsky.embed.defs#aspectRatio (JsonProperty: aspectRatio) [Optional]
-*/
+/// A representation of an image embedded in a Bluesky record (eg, a post).
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ImageEmbed {
+    /// The image data.
     #[serde(rename = "image")]
     pub image: Vec<u8>,
+
+    /// Alt text for the image.
     #[serde(rename = "alt")]
     pub alt: String,
+
+    /// The aspect ratio of the image.
     #[serde(rename = "aspectRatio", skip_serializing_if = "Option::is_none")]
     pub aspect_ratio: Option<AspectRatio>
 }
 
-/*    Type: view
-    Id: app.bsky.embed.images#view
-    Kind: object
-
-    Properties:
-    - images: #viewImage[] (JsonProperty: images) [Required]
-*/
+/// A view of an image embed.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ImageEmbedView {
+    /// A list of image embeds.
     #[serde(rename = "images")]
     pub images: Vec<ImageEmbed>
 }
 
-/*    Type: viewImage
-    Id: app.bsky.embed.images#viewImage
-    Kind: object
-
-    Properties:
-    - thumb: string (JsonProperty: thumb) [Required]
-    - fullsize: string (JsonProperty: fullsize) [Required]
-    - alt: string (JsonProperty: alt) [Required]
-    - aspect_ratio: app.bsky.embed.defs#aspectRatio (JsonProperty: aspectRatio) [Optional]
-*/
+/// A view of an image embed, with the image embed itself embedded. (?)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ImageEmbedViewImage {
+    /// Fully-qualified URL where a thumbnail of the image can be fetched. For
+    /// example, CDN location provided by the App View.
     #[serde(rename = "thumb")]
     pub thumb: String,
+
+    /// Fully-qualified URL where a large version of the image can be fetched.
+    /// May or may not be the exact original blob. For example, CDN location
+    /// provided by the App View.
     #[serde(rename = "fullsize")]
     pub fullsize: String,
+
+    /// Alt text for the image.
     #[serde(rename = "alt")]
     pub alt: String,
+
+    /// The aspect ratio of the image.
     #[serde(rename = "aspectRatio", skip_serializing_if = "Option::is_none")]
     pub aspect_ratio: Option<AspectRatio>
 }

--- a/atprotolib-rs/src/types/app_bsky/embed/record.rs
+++ b/atprotolib-rs/src/types/app_bsky/embed/record.rs
@@ -15,126 +15,131 @@ use crate::types::{
     app.bsky.embed.record
 */
 
-/*    Type: view
-    Id: app.bsky.embed.record#view
-    Kind: object
-
-    Properties:
-    - record: union  (JsonProperty: record) [Required]
-*/
+/// A view of a record embed.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.record#view")]
 pub struct RecordEmbedView {
+    /// The embedded record.
     #[serde(rename = "record")]
     pub record: RecordEmbedUnion
 }
 
+/// Represents a union of different types of record embeds.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RecordEmbedUnion {
+    /// A record embed.
     RecordEmbedViewRecord(RecordEmbedViewRecord),
+
+    /// A record embed that was not found.
     RecordEmbedViewNotFound(RecordEmbedViewNotFound),
+
+    /// A record embed that was blocked.
     RecordEmbedViewBlocked(RecordEmbedViewBlocked),
+
+    /// A record embed that was detached.
     RecordEmbedViewDetached(RecordEmbedViewDetached),
+
+    /// A generator view.
     GeneratorView(GeneratorView),
+
+    /// A list view.
     ListView(ListView),
+
+    /// A starter pack view.
     StarterPackViewBasic(StarterPackViewBasic),
+    
+    /// A labeler view.
     LabelerView(LabelerView)
 }
 
-/*    Type: viewRecord
-    Id: app.bsky.embed.record#viewRecord
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - author: app.bsky.actor.defs#profileViewBasic (JsonProperty: author) [Required]
-    - value: unknown  (JsonProperty: value) [Required]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - reply_count: integer  (JsonProperty: replyCount) [Optional]
-    - repost_count: integer  (JsonProperty: repostCount) [Optional]
-    - like_count: integer  (JsonProperty: likeCount) [Optional]
-    - quote_count: integer  (JsonProperty: quoteCount) [Optional]
-    - embeds: union[] (JsonProperty: embeds) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-*/
+/// A representation of a record embedded in a Bluesky record (eg, a post).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.record#viewRecord")]
 pub struct RecordEmbedViewRecord {
+    /// The URI of the record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The CID of the record.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The author of the record.
     #[serde(rename = "author")]
     pub author: ProfileViewBasic,
+
+    /// The value of the record.
     #[serde(rename = "value")]
     pub value: serde_json::Value,
+
+    /// Labels associated with the record.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
+
+    /// The number of replies to the record.
     #[serde(rename = "replyCount", default)]
     pub reply_count: i32,
+
+    /// The number of reposts of the record.
     #[serde(rename = "repostCount", default)]
     pub repost_count: i32,
+
+    /// The number of likes on the record.
     #[serde(rename = "likeCount", default)]
     pub like_count: i32,
+
+    /// The number of quotes of the record.
     #[serde(rename = "quoteCount", default)]
     pub quote_count: i32,
+
+    /// Embeds in the record.
     #[serde(rename = "embeds", skip_serializing_if = "Option::is_none")]
     pub embeds: Option<Vec<RecordEmbedUnion>>,
+
+    /// The date and time the record was indexed.
     #[serde(rename = "indexedAt")]
     pub indexed_at: DateTime<Utc>
 }
 
-/*    Type: viewNotFound
-    Id: app.bsky.embed.record#viewNotFound
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - not_found: boolean  (JsonProperty: notFound) [Required]
-*/
+/// Represents a record embed that was not found.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.record#viewNotFound")]
 pub struct RecordEmbedViewNotFound {
+    /// The URI of the record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// Whether the record was not found.
     #[serde(rename = "notFound", default)]
     pub not_found: bool
 }
 
-/*    Type: viewBlocked
-    Id: app.bsky.embed.record#viewBlocked
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - blocked: boolean  (JsonProperty: blocked) [Required]
-    - author: app.bsky.feed.defs#blockedAuthor (JsonProperty: author) [Required]
-*/
+/// Represents a record embed that was blocked.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.record#viewBlocked")]
 pub struct RecordEmbedViewBlocked {
+    /// The URI of the record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// Whether the record was blocked.
     #[serde(rename = "blocked", default)]
     pub blocked: bool,
+
+    /// The blocked author of the record.
     #[serde(rename = "author")]
     pub author: BlockedAuthor
 }
 
-/*    Type: viewDetached
-    Id: app.bsky.embed.record#viewDetached
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - detached: boolean  (JsonProperty: detached) [Required]
-*/
+/// Represents a record embed that was detached.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.record#viewDetached")]
 pub struct RecordEmbedViewDetached {
+    /// The URI of the record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// Whether the record was detached.
     #[serde(rename = "detached", default)]
     pub detached: bool
 }

--- a/atprotolib-rs/src/types/app_bsky/embed/record_with_media.rs
+++ b/atprotolib-rs/src/types/app_bsky/embed/record_with_media.rs
@@ -6,26 +6,28 @@ use super::{ExternalEmbedView, ImageEmbedView, RecordEmbedView, VideoEmbedView};
     app.bsky.embed.recordWithMedia
 */
 
-/*    Type: view
-    Id: app.bsky.embed.recordWithMedia#view
-    Kind: object
-
-    Properties:
-    - record: app.bsky.embed.record#view (JsonProperty: record) [Required]
-    - media: union  (JsonProperty: media) [Required]
-*/
+/// A representation of a record with media embedded in a Bluesky record (eg, a post).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.embed.recordWithMedia#view")]
 pub struct RecordWithMediaEmbedView {
+    /// The embedded record.
     #[serde(rename = "record")]
     pub record: RecordEmbedView,
+
+    /// The media embedded in the record.
     #[serde(rename = "media")]
     pub media: RecordWithMediaEmbedViewMedia
 }
 
+/// Represents the media embedded in a record with media.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RecordWithMediaEmbedViewMedia {
+    /// Images embedded in the record.
     Images(ImageEmbedView),
+
+    /// Videos embedded in the record.
     Videos(VideoEmbedView),
+
+    /// External content embedded in the record.
     External(ExternalEmbedView)
 }

--- a/atprotolib-rs/src/types/app_bsky/feed/api_calls.rs
+++ b/atprotolib-rs/src/types/app_bsky/feed/api_calls.rs
@@ -3,6 +3,17 @@ use crate::{
     types::app_bsky
 };
 
+/// Get a list of feeds (feed generator records) created by the actor (in the actor's repo).
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the feeds of.
+/// * `limit` - The maximum number of feeds to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_actor_feeds(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -40,6 +51,17 @@ pub async fn get_actor_feeds(
     }
 }
 
+/// Get a list of posts liked by an actor. Requires auth, actor must be the requesting account.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the likes of.
+/// * `limit` - The maximum number of likes to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_actor_likes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -77,6 +99,19 @@ pub async fn get_actor_likes(
     }
 }
 
+/// Get a view of an actor's 'author feed' (post and reposts by the author). Does not require auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the author feed of.
+/// * `limit` - The maximum number of posts to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
+/// * `filter` - A filter for the feed.
+/// * `include_pins` - Whether to include pinned posts in the feed.
 pub async fn get_author_feed(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/app_bsky/feed/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/feed/defs.rs
@@ -16,254 +16,259 @@ use crate::types::{
     com_atproto::label::Label
 };
 
-/*    Type: postView
-    Id: app.bsky.feed.defs#postView
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - author: app.bsky.actor.defs#profileViewBasic (JsonProperty: author) [Required]
-    - record: unknown  (JsonProperty: record) [Required]
-    - embed: union  (JsonProperty: embed) [Optional]
-    - reply_count: integer  (JsonProperty: replyCount) [Optional]
-    - repost_count: integer  (JsonProperty: repostCount) [Optional]
-    - like_count: integer  (JsonProperty: likeCount) [Optional]
-    - quote_count: integer  (JsonProperty: quoteCount) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-    - viewer: #viewerState (JsonProperty: viewer) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - threadgate: #threadgateView (JsonProperty: threadgate) [Optional]
-*/
+/// Represents a post view.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#postView")]
 pub struct PostView {
+    /// The URI of the post.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The content ID of the post.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The profile of the author.
     #[serde(rename = "author")]
     pub author: ProfileViewBasic,
+
+    /// The record of the post.
     #[serde(rename = "record")]
     pub record: serde_json::Value,
+
+    /// Embed information for the post.
     #[serde(rename = "embed", skip_serializing_if = "Option::is_none")]
     pub embed: Option<PostViewEmbed>,
+
+    /// The number of replies to the post.
     #[serde(rename = "replyCount", default)]
     pub reply_count: i32,
+
+    /// The number of reposts of the post.
     #[serde(rename = "repostCount", default)]
     pub repost_count: i32,
+
+    /// The number of likes on the post.
     #[serde(rename = "likeCount", default)]
     pub like_count: i32,
+
+    /// The number of quotes of the post.
     #[serde(rename = "quoteCount", default)]
     pub quote_count: i32,
+
+    /// The date and time the post was indexed.
     #[serde(rename = "indexedAt")]
     pub indexed_at: DateTime<Utc>,
+
+    /// Information about the viewer's state of the post.
     #[serde(rename = "viewer", skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>,
+
+    /// Labels for the post.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
+
+    /// Unknown.
     #[serde(rename = "threadgate", skip_serializing_if = "Option::is_none")]
     pub threadgate: Option<ThreadgateView>
 }
 
+/// Represents an embed for a post view.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PostViewEmbed {
+    /// An image embed.
     Images(ImageEmbedView),
+
+    /// A video embed.
     Video(VideoEmbedView),
+
+    /// An external embed.
     External(ExternalEmbedView),
+
+    /// A record embed.
     Record(RecordEmbedView),
+
+    /// A record with media embed.
     RecordWithMedia(RecordWithMediaEmbedView)
 }
 
-/*    Type: viewerState
-    Id: app.bsky.feed.defs#viewerState
-    Kind: object
-
-    Properties:
-    - repost: string (JsonProperty: repost) [Optional]
-    - like: string (JsonProperty: like) [Optional]
-    - thread_muted: boolean  (JsonProperty: threadMuted) [Optional]
-    - reply_disabled: boolean  (JsonProperty: replyDisabled) [Optional]
-    - embedding_disabled: boolean  (JsonProperty: embeddingDisabled) [Optional]
-    - pinned: boolean  (JsonProperty: pinned) [Optional]
-*/
+/// Metadata about the requesting account's relationship with the subject content. Only has meaningful content for authed requests.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#viewerState")]
 pub struct ViewerState {
+    /// ATProto URI of a repost. (?)
     #[serde(rename = "repost", skip_serializing_if = "Option::is_none")]
     pub repost: Option<String>,
+
+    /// ATProto URI of a like. (?)
     #[serde(rename = "like", skip_serializing_if = "Option::is_none")]
     pub like: Option<String>,
+
+    /// Whether the thread is muted.
     #[serde(rename = "threadMuted", default)]
     pub thread_muted: bool,
+
+    /// Whether replies are disabled.
     #[serde(rename = "replyDisabled", default)]
     pub reply_disabled: bool,
+
+    /// Whether embedding is disabled.
     #[serde(rename = "embeddingDisabled", default)]
     pub embedding_disabled: bool,
+
+    /// Whether the post is pinned.
     #[serde(rename = "pinned", default)]
     pub pinned: bool
 }
 
-/*    Type: feedViewPost
-    Id: app.bsky.feed.defs#feedViewPost
-    Kind: object
-
-    Properties:
-    - post: #postView (JsonProperty: post) [Required]
-    - reply: #replyRef (JsonProperty: reply) [Optional]
-    - reason: union  (JsonProperty: reason) [Optional]
-    - feed_context: string (JsonProperty: feedContext) [Optional]
-*/
+/// Represents a post in a feed view.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#feedViewPost")]
 pub struct FeedViewPost {
+    /// The post.
     #[serde(rename = "post")]
     pub post: PostView,
+
+    /// The parent post the post is replying to.
     #[serde(rename = "reply", skip_serializing_if = "Option::is_none")]
     pub reply: Option<ReplyRef>,
+
+    /// The reason for the post.
     #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
     pub reason: Option<FeedViewPostReason>,
+
+    /// Context provided by a feed generator that may be passed back alongside interactions.
     #[serde(rename = "feedContext", skip_serializing_if = "Option::is_none")]
     pub feed_context: Option<String>
 }
 
+/// Represents a reason for a post in a feed view.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum FeedViewPostReason {
+    /// The post is a repost.
     Repost(ReasonRepost),
+
+    /// The post is pinned.
     Pin(ReasonPin)
 }
 
-/*    Type: replyRef
-    Id: app.bsky.feed.defs#replyRef
-    Kind: object
-
-    Properties:
-    - root: union  (JsonProperty: root) [Required]
-    - parent: union  (JsonProperty: parent) [Required]
-    - grandparent_author: app.bsky.actor.defs#profileViewBasic (JsonProperty: grandparentAuthor) [Optional]
-*/
+/// Represents a reference to a reply.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#replyRef")]
 pub struct ReplyRef {
+    /// The root post.
     #[serde(rename = "root")]
     pub root: ReplyRefItem,
+
+    /// The parent post.
     #[serde(rename = "parent")]
     pub parent: ReplyRefItem,
+
+    /// If the parent reply is to another post, this is the author of the original post.
     #[serde(rename = "grandparentAuthor", skip_serializing_if = "Option::is_none")]
     pub grandparent_author: Option<ProfileViewBasic>
 }
 
+/// Represents an item in a reply reference.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ReplyRefItem {
+    /// A post.
     Post(PostView),
+    
+    /// The post was not found.
     NotFoundPost(NotFoundPost),
+
+    /// The post is blocked.
     BlockedPost(BlockedPost)
 }
 
-/*    Type: reasonRepost
-    Id: app.bsky.feed.defs#reasonRepost
-    Kind: object
-
-    Properties:
-    - by: app.bsky.actor.defs#profileViewBasic (JsonProperty: by) [Required]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-*/
+/// Represents a reason for a repost.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#reasonRepost")]
 pub struct ReasonRepost {
+    /// The profile of the user who reposted the post.
     #[serde(rename = "by")]
     pub by: ProfileViewBasic,
+
+    /// The date and time the post was indexed.
     #[serde(rename = "indexedAt")]
     pub indexed_at: DateTime<Utc>
 }
 
-/*    Type: reasonPin
-    Id: app.bsky.feed.defs#reasonPin
-    Kind: object
-
-    Properties:
-*/
+/// Represents a reason for a pin.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#reasonPin")]
 pub struct ReasonPin {}
 
-/*    Type: threadViewPost
-    Id: app.bsky.feed.defs#threadViewPost
-    Kind: object
-
-    Properties:
-    - post: #postView (JsonProperty: post) [Required]
-    - parent: union  (JsonProperty: parent) [Optional]
-    - replies: union[] (JsonProperty: replies) [Optional]
-*/
+/// Represents a post in a thread view.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#threadViewPost")]
 pub struct ThreadViewPost {
+    /// The post.
     #[serde(rename = "post")]
     pub post: PostView,
+
+    /// The parent of the post in the thread.
     #[serde(rename = "parent", skip_serializing_if = "Option::is_none")]
     pub parent: Option<ThreadViewPostItem>,
+
+    /// Replies to the post.
     #[serde(rename = "replies", skip_serializing_if = "Option::is_none")]
     pub replies: Option<Vec<ThreadViewPostItem>>
 }
 
+/// Represents an item in a thread view post.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ThreadViewPostItem {
+    /// A post.
     ThreadPost(Box<ThreadViewPost>),
+
+    /// The post was not found.
     NotFoundPost(NotFoundPost),
+
+    /// The post is blocked.
     BlockedPost(BlockedPost)
 }
 
-/*    Type: notFoundPost
-    Id: app.bsky.feed.defs#notFoundPost
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - not_found: boolean  (JsonProperty: notFound) [Required]
-*/
+/// Represents a post not found.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#notFoundPost")]
 pub struct NotFoundPost {
+    /// The URI of the post.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// Whether the post was not found.
     #[serde(rename = "notFound", default)]
     pub not_found: bool
 }
 
-/*    Type: blockedPost
-    Id: app.bsky.feed.defs#blockedPost
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - blocked: boolean  (JsonProperty: blocked) [Required]
-    - author: #blockedAuthor (JsonProperty: author) [Required]
-*/
+/// Represents a blocked post.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#blockedPost")]
 pub struct BlockedPost {
+    /// The URI of the post.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// Whether the post is blocked.
     #[serde(rename = "blocked", default)]
     pub blocked: bool,
+
+    /// The author of the post that is blocked.
     #[serde(rename = "author")]
     pub author: BlockedAuthor
 }
 
-/*    Type: blockedAuthor
-    Id: app.bsky.feed.defs#blockedAuthor
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - viewer: app.bsky.actor.defs#viewerState (JsonProperty: viewer) [Optional]
-*/
+/// Represents a blocked author.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.feed.defs#blockedAuthor")]
 pub struct BlockedAuthor {
+    /// The DID of the blocked author.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The relationship of the blocked author.
     #[serde(rename = "viewer", skip_serializing_if = "Option::is_none")]
     pub viewer: Option<ViewerState>
 }

--- a/atprotolib-rs/src/types/app_bsky/feed/get_actor_feeds.rs
+++ b/atprotolib-rs/src/types/app_bsky/feed/get_actor_feeds.rs
@@ -6,18 +6,14 @@ use super::defs::GeneratorView;
     app.bsky.feed.getActorFeeds
 */
 
-/*    Type: response
-    Id: app.bsky.feed.getActorFeeds#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - feeds: app.bsky.feed.defs#generatorView[] (JsonProperty: feeds) [Required]
-*/
+/// A response to getting feeds for an actor.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetActorFeedsResponse {
+    /// A cursor for the stream.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// A list of feeds.
     #[serde(rename = "feeds")]
     pub feeds: Vec<GeneratorView>
 }

--- a/atprotolib-rs/src/types/app_bsky/feed/get_actor_likes.rs
+++ b/atprotolib-rs/src/types/app_bsky/feed/get_actor_likes.rs
@@ -6,18 +6,14 @@ use super::defs::FeedViewPost;
     app.bsky.feed.getActorLikes
 */
 
-/*    Type: response
-    Id: app.bsky.feed.getActorLikes#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - feed: app.bsky.feed.defs#feedViewPost[] (JsonProperty: feed) [Required]
-*/
+/// A response to getting likes for an actor.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetActorLikesResponse {
+    /// A cursor for the stream.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// A list of posts.
     #[serde(rename = "feed")]
     pub feed: Vec<FeedViewPost>
 }

--- a/atprotolib-rs/src/types/app_bsky/feed/get_author_feed.rs
+++ b/atprotolib-rs/src/types/app_bsky/feed/get_author_feed.rs
@@ -6,18 +6,14 @@ use super::defs::FeedViewPost;
     app.bsky.feed.getAuthorFeed
 */
 
-/*    Type: response
-    Id: app.bsky.feed.getAuthorFeed#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - feed: app.bsky.feed.defs#feedViewPost[] (JsonProperty: feed) [Required]
-*/
+/// A response to getting a feed for an author.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetAuthorFeedResponse {
+    /// A cursor for the stream.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// A list of posts.
     #[serde(rename = "feed")]
     pub feed: Vec<FeedViewPost>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/api_calls.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/api_calls.rs
@@ -3,6 +3,17 @@ use crate::{
     types::app_bsky
 };
 
+/// Get a list of starter packs created by the actor.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the starter packs of.
+/// * `limit` - The maximum number of starter packs to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_actor_starter_packs(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -44,6 +55,16 @@ pub async fn get_actor_starter_packs(
     }
 }
 
+/// Enumerates which accounts the requesting account is currently blocking. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of accounts to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_blocks(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -79,6 +100,17 @@ pub async fn get_blocks(
     }
 }
 
+/// Enumerates accounts which follow a specified account (actor).
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the followers of.
+/// * `limit` - The maximum number of followers to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_followers(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -116,6 +148,17 @@ pub async fn get_followers(
     }
 }
 
+/// Enumerates accounts which a specified account (actor) follows.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the profiles of.
+/// * `limit` - The maximum number of profiles to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_follows(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -153,6 +196,17 @@ pub async fn get_follows(
     }
 }
 
+/// Enumerates accounts which follow a specified account (actor) and are followed by the viewer.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the followers of.
+/// * `limit` - The maximum number of followers to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_known_followers(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -193,6 +247,16 @@ pub async fn get_known_followers(
     }
 }
 
+/// Get mod lists that the requesting account (actor) is blocking. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of mod lists to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_list_blocks(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -228,6 +292,16 @@ pub async fn get_list_blocks(
     }
 }
 
+/// Enumerates mod lists that the requesting account (actor) currently has muted. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of mod lists to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_list_mutes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -263,6 +337,17 @@ pub async fn get_list_mutes(
     }
 }
 
+/// Gets a 'view' (with additional context) of a specified list.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `list` - The list to fetch.
+/// * `limit` - The maximum number of items to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_list(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -300,6 +385,17 @@ pub async fn get_list(
     }
 }
 
+/// Enumerates the lists created by a specified account (actor).
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the lists of.
+/// * `limit` - The maximum number of lists to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_lists(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -337,6 +433,16 @@ pub async fn get_lists(
     }
 }
 
+/// Enumerates accounts that the requesting account (actor) currently has muted. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of accounts to return. Defaults to 50.
+/// * `cursor` - A cursor for pagination.
 pub async fn get_mutes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -372,6 +478,15 @@ pub async fn get_mutes(
     }
 }
 
+/// Gets a view of a starter pack.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `starter_pack` - The URI of the starter pack to fetch.
 pub async fn get_starter_pack(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -399,6 +514,15 @@ pub async fn get_starter_pack(
     }
 }
 
+/// Enumerates follows similar to a given account (actor). Expected use is to recommend additional accounts immediately after following one account.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `actor` - Handle or DID of the account to fetch the suggested follows for.
 pub async fn get_suggested_follows_by_actor(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -430,6 +554,15 @@ pub async fn get_suggested_follows_by_actor(
     }
 }
 
+/// Creates a mute relationship for the specified list of accounts. Mutes are private in Bluesky. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to mute a list of actors.
 pub async fn mute_actor_list(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -452,6 +585,15 @@ pub async fn mute_actor_list(
     }
 }
 
+/// Creates a mute relationship for the specified account. Mutes are private in Bluesky. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to mute an actor.
 pub async fn mute_actor(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -474,6 +616,15 @@ pub async fn mute_actor(
     }
 }
 
+/// Mutes a thread preventing notifications from the thread and any of its children. Mutes are private in Bluesky. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to mute a thread.
 pub async fn mute_thread(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -496,6 +647,15 @@ pub async fn mute_thread(
     }
 }
 
+/// Unmutes the specified list of accounts. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to unmute a list of actors.
 pub async fn unmute_actor_list(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -518,6 +678,15 @@ pub async fn unmute_actor_list(
     }
 }
 
+/// Unmutes the specified account. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to unmute an actor.
 pub async fn unmute_actor(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -540,6 +709,15 @@ pub async fn unmute_actor(
     }
 }
 
+/// Unmutes the specified thread. Requires auth.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to make the request to.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to unmute a thread.
 pub async fn unmute_thread(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/app_bsky/graph/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/defs.rs
@@ -10,187 +10,189 @@ use crate::types::{
     com_atproto::label::Label
 };
 
-/*    Type: listViewBasic
-    Id: app.bsky.graph.defs#listViewBasic
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - name: string (JsonProperty: name) [Required]
-    - purpose: #listPurpose (JsonProperty: purpose) [Required]
-    - avatar: string (JsonProperty: avatar) [Optional]
-    - list_item_count: integer  (JsonProperty: listItemCount) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - viewer: #listViewerState (JsonProperty: viewer) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Optional]
-*/
+/// A basic view of a list.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListViewBasic {
+    /// The URI of the list.
     uri: String,
+
+    /// The CID of the list.
     cid: String,
+
+    /// The name of the list.
     name: String,
+
+    /// The purpose of the list.
     purpose: String,
+
+    /// The URI for the avatar of the list.
     avatar: Option<String>,
+
+    /// The number of items in the list.
     list_item_count: i32,
+
+    /// The labels associated with the list.
     labels: Option<Vec<Label>>,
+
+    /// A representation of the viewer's relationship with the list.
     viewer: Option<ListViewerState>,
+
+    /// The date and time the list was indexed.
     indexed_at: Option<DateTime<Utc>>
 }
 
-/*    Type: listView
-    Id: app.bsky.graph.defs#listView
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - creator: app.bsky.actor.defs#profileView (JsonProperty: creator) [Required]
-    - name: string (JsonProperty: name) [Required]
-    - purpose: #listPurpose (JsonProperty: purpose) [Required]
-    - description: string (JsonProperty: description) [Optional]
-    - description_facets: app.bsky.richtext.facet[] (JsonProperty: descriptionFacets) [Optional]
-    - avatar: string (JsonProperty: avatar) [Optional]
-    - list_item_count: integer  (JsonProperty: listItemCount) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - viewer: #listViewerState (JsonProperty: viewer) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-*/
+/// A view of a list.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.graph.defs#listView")]
 pub struct ListView {
+    /// The URI of the list.
     uri: String,
+
+    /// The CID of the list.
     cid: String,
+
+    /// The creator of the list.
     creator: ProfileView,
+
+    /// The name of the list.
     name: String,
+
+    /// The purpose of the list.
     purpose: String,
+
+    /// A description of the list.
     description: Option<String>,
+
+    /// A description of the list, in rich text.
     description_facets: Option<Vec<RichTextFacet>>,
+
+    /// The URI for the avatar of the list.
     avatar: Option<String>,
+
+    /// The number of items in the list.
     list_item_count: i32,
+
+    /// The labels associated with the list.
     labels: Option<Vec<Label>>,
+
+    /// A representation of the viewer's relationship with the list.
     viewer: Option<ListViewerState>,
+
+    /// The date and time the list was indexed.
     indexed_at: DateTime<Utc>
 }
 
-/*    Type: listItemView
-    Id: app.bsky.graph.defs#listItemView
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - subject: app.bsky.actor.defs#profileView (JsonProperty: subject) [Required]
-*/
+/// An item in a list.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListItemView {
+    /// The URI of the profile.
     uri: String,
+
+    /// The profile.
     subject: ProfileView
 }
 
-/*    Type: starterPackView
-    Id: app.bsky.graph.defs#starterPackView
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - record: unknown  (JsonProperty: record) [Required]
-    - creator: app.bsky.actor.defs#profileViewBasic (JsonProperty: creator) [Required]
-    - list: #listViewBasic (JsonProperty: list) [Optional]
-    - list_items_sample: #listItemView[] (JsonProperty: listItemsSample) [Optional]
-    - feeds: app.bsky.feed.defs#generatorView[] (JsonProperty: feeds) [Optional]
-    - joined_week_count: integer  (JsonProperty: joinedWeekCount) [Optional]
-    - joined_all_time_count: integer  (JsonProperty: joinedAllTimeCount) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-*/
+/// A view of a starter pack.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StarterPackView {
+    /// The URI of the starter pack.
     uri: String,
+
+    /// The CID of the starter pack.
     cid: String,
+
+    /// The record of the starter pack.
     record: serde_json::Value,
+
+    /// The creator of the starter pack.
     creator: ProfileViewBasic,
+
+    /// The list associated with the starter pack.
     list: Option<ListViewBasic>,
+
+    /// A sample of items in the list.
     list_items_sample: Option<Vec<ListItemView>>,
+
+    /// Feed generators associated with the starter pack.
     feeds: Option<Vec<GeneratorView>>,
+
+    /// Number of starter packs joined in the last week.
     joined_week_count: i32,
+
+    /// Number of starter packs joined all time.
     joined_all_time_count: i32,
+
+    /// The labels associated with the starter pack.
     labels: Option<Vec<Label>>,
+
+    /// The date and time the starter pack was indexed.
     indexed_at: DateTime<Utc>
 }
 
-/*    Type: starterPackViewBasic
-    Id: app.bsky.graph.defs#starterPackViewBasic
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - record: unknown  (JsonProperty: record) [Required]
-    - creator: app.bsky.actor.defs#profileViewBasic (JsonProperty: creator) [Required]
-    - list_item_count: integer  (JsonProperty: listItemCount) [Optional]
-    - joined_week_count: integer  (JsonProperty: joinedWeekCount) [Optional]
-    - joined_all_time_count: integer  (JsonProperty: joinedAllTimeCount) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-*/
+/// A basic view of a starter pack.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.graph.defs#starterPackViewBasic")]
 pub struct StarterPackViewBasic {
+    /// The URI of the starter pack.
     uri: String,
+
+    /// The CID of the starter pack.
     cid: String,
+
+    /// The record of the starter pack.
     record: serde_json::Value,
+
+    /// The creator of the starter pack.
     creator: ProfileViewBasic,
+
+    /// The count of items in the list.
     list_item_count: i32,
+
+    /// The number of starter packs joined in the last week.
     joined_week_count: i32,
+
+    /// The number of starter packs joined all time.
     joined_all_time_count: i32,
+
+    /// The labels associated with the starter pack.
     labels: Option<Vec<Label>>,
+
+    /// The date and time the starter pack was indexed.
     indexed_at: DateTime<Utc>
 }
 
-/*    Type: listViewerState
-    Id: app.bsky.graph.defs#listViewerState
-    Kind: object
-
-    Properties:
-    - muted: boolean  (JsonProperty: muted) [Optional]
-    - blocked: string (JsonProperty: blocked) [Optional]
-*/
+/// Represents the relationship between a viewer and a list.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.graph.defs#listViewerState")]
 pub struct ListViewerState {
+    /// Whether the list is muted.
     muted: bool,
+
+    /// Whether the list is blocked.
     blocked: Option<String>
 }
 
-/*    Type: notFoundActor
-    Id: app.bsky.graph.defs#notFoundActor
-    Kind: object
-
-    Properties:
-    - actor: string (JsonProperty: actor) [Required]
-    - not_found: boolean  (JsonProperty: notFound) [Required]
-*/
+/// Represents an actor not found.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.graph.defs#notFoundActor")]
 pub struct NotFoundActor {
+    /// The URI of the actor.
     actor: String,
+
+    /// Whether the actor is not found.
     not_found: bool
 }
 
-/*    Type: relationship
-    Id: app.bsky.graph.defs#relationship
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - following: string (JsonProperty: following) [Optional]
-    - followed_by: string (JsonProperty: followedBy) [Optional]
-*/
+/// Represents a relationship.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.graph.defs#relationship")]
 pub struct Relationship {
+    /// The URI of the actor.
     did: String,
+
+    /// If the actor follows this DID, this is the AT-URI of the follow record.
     following: Option<String>,
+
+    /// If the actor is followed by this DID, contains the AT-URI of the follow record.
     followed_by: Option<String>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_actor_starter_packs.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_actor_starter_packs.rs
@@ -6,16 +6,12 @@ use super::defs::StarterPackViewBasic;
     app.bsky.graph.getActorStarterPacks
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getActorStarterPacks#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - starter_packs: app.bsky.graph.defs#starterPackViewBasic[] (JsonProperty: starterPacks) [Required]
-*/
+/// The response to a request for a user's starter packs.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetActorStarterPacksResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's starter packs.
     starter_packs: Vec<StarterPackViewBasic>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_blocks.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_blocks.rs
@@ -6,16 +6,12 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getBlocks
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getBlocks#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - blocks: app.bsky.actor.defs#profileView[] (JsonProperty: blocks) [Required]
-*/
+/// The response to a request for a user's blocked profiles.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetBlocksResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's blocked profiles.
     blocks: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_followers.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_followers.rs
@@ -6,18 +6,15 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getFollowers
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getFollowers#response
-    Kind: object
-
-    Properties:
-    - subject: app.bsky.actor.defs#profileView (JsonProperty: subject) [Required]
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - followers: app.bsky.actor.defs#profileView[] (JsonProperty: followers) [Required]
-*/
+/// The response to a request for a user's followers.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetFollowersResponse {
+    /// The subject of the request.
     subject: ProfileView,
+
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's followers.
     followers: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_follows.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_follows.rs
@@ -6,18 +6,15 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getFollows
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getFollows#response
-    Kind: object
-
-    Properties:
-    - subject: app.bsky.actor.defs#profileView (JsonProperty: subject) [Required]
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - follows: app.bsky.actor.defs#profileView[] (JsonProperty: follows) [Required]
-*/
+/// The response to a request for the profiles a user follows.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetFollowsResponse {
+    /// The subject of the request.
     subject: ProfileView,
+
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the profiles the user follows.
     follows: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_known_followers.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_known_followers.rs
@@ -6,18 +6,15 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getKnownFollowers
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getKnownFollowers#response
-    Kind: object
-
-    Properties:
-    - subject: app.bsky.actor.defs#profileView (JsonProperty: subject) [Required]
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - followers: app.bsky.actor.defs#profileView[] (JsonProperty: followers) [Required]
-*/
+/// The response to a request for a user's known followers.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetKnownFollowersResponse {
+    /// The subject of the request.
     subject: ProfileView,
+
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's known followers.
     followers: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_list.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_list.rs
@@ -6,18 +6,15 @@ use super::defs::{ListItemView, ListView};
     app.bsky.graph.getList
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getList#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - list: app.bsky.graph.defs#listView (JsonProperty: list) [Required]
-    - items: app.bsky.graph.defs#listItemView[] (JsonProperty: items) [Required]
-*/
+/// The response to a request for a list.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetListResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// The list.
     list: ListView,
+
+    /// A list of the list's items.
     items: Vec<ListItemView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_list_blocks.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_list_blocks.rs
@@ -6,16 +6,12 @@ use super::defs::ListView;
     app.bsky.graph.getListBlocks
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getListBlocks#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - lists: app.bsky.graph.defs#listView[] (JsonProperty: lists) [Required]
-*/
+/// The response to a request for a user's blocked lists.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetListBlocksResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's blocked lists.
     lists: Vec<ListView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_list_mutes.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_list_mutes.rs
@@ -6,16 +6,12 @@ use super::defs::ListView;
     app.bsky.graph.getListMutes
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getListMutes#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - lists: app.bsky.graph.defs#listView[] (JsonProperty: lists) [Required]
-*/
+/// The response to a request for a user's mute lists.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetListMutesResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's mute lists.
     lists: Vec<ListView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_lists.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_lists.rs
@@ -6,16 +6,12 @@ use super::defs::ListView;
     app.bsky.graph.getLists
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getLists#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - lists: app.bsky.graph.defs#listView[] (JsonProperty: lists) [Required]
-*/
+/// The response to a request for lists.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetListsResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the lists.
     lists: Vec<ListView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_mutes.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_mutes.rs
@@ -6,16 +6,12 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getMutes
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getMutes#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - mutes: app.bsky.actor.defs#profileView[] (JsonProperty: mutes) [Required]
-*/
+/// The response to a request for a user's muted profiles.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetMutesResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's muted profiles.
     mutes: Vec<ProfileView>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_relationships.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_relationships.rs
@@ -6,22 +6,22 @@ use super::{NotFoundActor, Relationship};
     app.bsky.graph.getRelationships
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getRelationships#response
-    Kind: object
-
-    Properties:
-    - actor: string (JsonProperty: actor) [Optional]
-    - relationships: union[] (JsonProperty: relationships) [Required]
-*/
+/// The response to a request for a user's relationships.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetRelationshipsResponse {
+    /// The account the relationships are for.
     actor: Option<String>,
+
+    /// A list of the user's relationships.
     relationships: Vec<GetRelationshipsResponseRelationships>
 }
 
+/// A type union for the relationships.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum GetRelationshipsResponseRelationships {
+    /// A relationship.
     Relationship(Relationship),
+
+    /// An actor that was not found.
     NotFoundActor(NotFoundActor)
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_starter_pack.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_starter_pack.rs
@@ -6,14 +6,9 @@ use super::defs::StarterPackView;
     app.bsky.graph.getStarterPack
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getStarterPack#response
-    Kind: object
-
-    Properties:
-    - starter_pack: app.bsky.graph.defs#starterPackView (JsonProperty: starterPack) [Required]
-*/
+/// The response to a request for a starter pack.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetStarterPackResponse {
+    /// The starter pack.
     starter_pack: StarterPackView
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_starter_packs.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_starter_packs.rs
@@ -6,14 +6,9 @@ use super::defs::StarterPackViewBasic;
     app.bsky.graph.getStarterPacks
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getStarterPacks#response
-    Kind: object
-
-    Properties:
-    - starter_packs: app.bsky.graph.defs#starterPackViewBasic[] (JsonProperty: starterPacks) [Required]
-*/
+/// The response to a request for starter packs.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetStarterPacksResponse {
+    /// A list of the starter packs.
     starter_packs: Vec<StarterPackViewBasic>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/get_suggested_follows_by_actor.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/get_suggested_follows_by_actor.rs
@@ -6,16 +6,12 @@ use crate::types::app_bsky::actor::ProfileView;
     app.bsky.graph.getSuggestedFollowsByActor
 */
 
-/*    Type: response
-    Id: app.bsky.graph.getSuggestedFollowsByActor#response
-    Kind: object
-
-    Properties:
-    - suggestions: app.bsky.actor.defs#profileView[] (JsonProperty: suggestions) [Required]
-    - is_fallback: boolean  (JsonProperty: isFallback) [Optional]
-*/
+/// The response to a request for suggested follows for a user.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetSuggestedFollowsByActorResponse {
+    /// A list of suggested profiles.
     suggestions: Vec<ProfileView>,
+
+    /// Whether the response is a fallback.
     is_fallback: bool
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/mute_actor.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/mute_actor.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.muteActor
 */
 
-/*    Type: request
-    Id: app.bsky.graph.muteActor#request
-    Kind: object
-
-    Properties:
-    - actor: string (JsonProperty: actor) [Required]
-*/
+/// The request to mute an actor.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MuteActorRequest {
+    /// The URI of the actor to mute.
     actor: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/mute_actor_list.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/mute_actor_list.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.muteActorList
 */
 
-/*    Type: request
-    Id: app.bsky.graph.muteActorList#request
-    Kind: object
-
-    Properties:
-    - list: string (JsonProperty: list) [Required]
-*/
+/// The request to mute an actor list.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MuteActorListRequest {
+    /// The list.
     list: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/mute_thread.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/mute_thread.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.muteThread
 */
 
-/*    Type: request
-    Id: app.bsky.graph.muteThread#request
-    Kind: object
-
-    Properties:
-    - root: string (JsonProperty: root) [Required]
-*/
+/// The request to mute a thread.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MuteThreadRequest {
+    /// The URI of the thread to mute.
     root: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/search_starter_packs.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/search_starter_packs.rs
@@ -6,16 +6,12 @@ use super::defs::StarterPackViewBasic;
     app.bsky.graph.searchStarterPacks
 */
 
-/*    Type: response
-    Id: app.bsky.graph.searchStarterPacks#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - starter_packs: app.bsky.graph.defs#starterPackViewBasic[] (JsonProperty: starterPacks) [Required]
-*/
+/// The response to a request to search for starter packs.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SearchStarterPacksResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the starter packs.
     starter_packs: Vec<StarterPackViewBasic>
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/starterpack.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/starterpack.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.starterpack
 */
 
-/*    Type: feedItem
-    Id: app.bsky.graph.starterpack#feedItem
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-*/
+/// A feed item for a starter pack.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StarterPackFeedItem {
+    /// The URI of the feed item.
     uri: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/unmute_actor.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/unmute_actor.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.unmuteActor
 */
 
-/*    Type: request
-    Id: app.bsky.graph.unmuteActor#request
-    Kind: object
-
-    Properties:
-    - actor: string (JsonProperty: actor) [Required]
-*/
+/// The request to unmute an actor.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UnmuteActorRequest {
+    /// The URI of the actor to unmute.
     actor: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/unmute_actor_list.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/unmute_actor_list.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.unmuteActorList
 */
 
-/*    Type: request
-    Id: app.bsky.graph.unmuteActorList#request
-    Kind: object
-
-    Properties:
-    - list: string (JsonProperty: list) [Required]
-*/
+/// The request to unmute an actor list.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UnmuteActorListRequest {
+    /// The list.
     list: String
 }

--- a/atprotolib-rs/src/types/app_bsky/graph/unmute_thread.rs
+++ b/atprotolib-rs/src/types/app_bsky/graph/unmute_thread.rs
@@ -4,14 +4,9 @@ use serde::{Deserialize, Serialize};
     app.bsky.graph.unmuteThread
 */
 
-/*    Type: request
-    Id: app.bsky.graph.unmuteThread#request
-    Kind: object
-
-    Properties:
-    - root: string (JsonProperty: root) [Required]
-*/
+/// The request to unmute a thread.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UnmuteThreadRequest {
+    /// The URI of the thread to unmute.
     root: String
 }

--- a/atprotolib-rs/src/types/app_bsky/labeler/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/labeler/defs.rs
@@ -6,79 +6,73 @@ use crate::types::{
     com_atproto::label::{Label, LabelValueDefinition}
 };
 
-/*    Type: labelerView
-    Id: app.bsky.labeler.defs#labelerView
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - creator: app.bsky.actor.defs#profileView (JsonProperty: creator) [Required]
-    - like_count: integer  (JsonProperty: likeCount) [Optional]
-    - viewer: #labelerViewerState (JsonProperty: viewer) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-*/
+/// A view of a labeler.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.labeler.defs#labelerView")]
 pub struct LabelerView {
+    /// The URI of the labeler.
     uri: String,
+
+    /// The CID of the labeler.
     cid: String,
+
+    /// The creator of the labeler.
     creator: ProfileView,
+
+    /// The number of likes the labeler has.
     like_count: i32,
+
+    /// A representation of the viewer's relationship with the labeler.
     viewer: Option<LabelerViewerState>,
+
+    /// The date and time the labeler was indexed.
     indexed_at: DateTime<Utc>,
+
+    /// The labels associated with the labeler.
     labels: Option<Vec<Label>>
 }
 
-/*    Type: labelerViewDetailed
-    Id: app.bsky.labeler.defs#labelerViewDetailed
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - creator: app.bsky.actor.defs#profileView (JsonProperty: creator) [Required]
-    - policies: app.bsky.labeler.defs#labelerPolicies (JsonProperty: policies) [Required]
-    - like_count: integer  (JsonProperty: likeCount) [Optional]
-    - viewer: #labelerViewerState (JsonProperty: viewer) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-*/
+/// A detailed view of a labeler.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LabelerViewDetailed {
+    /// The URI of the labeler.
     uri: String,
+
+    /// The CID of the labeler.
     cid: String,
+
+    /// The creator of the labeler.
     creator: ProfileView,
+
+    /// The policies of the labeler.
     policies: LabelerPolicies,
+
+    /// The number of likes the labeler has.
     like_count: i32,
+
+    /// A representation of the viewer's relationship with the labeler.
     viewer: Option<LabelerViewerState>,
+
+    /// The date and time the labeler was indexed.
     indexed_at: DateTime<Utc>,
+
+    /// The labels associated with the labeler.
     labels: Option<Vec<Label>>
 }
 
-/*    Type: labelerViewerState
-    Id: app.bsky.labeler.defs#labelerViewerState
-    Kind: object
-
-    Properties:
-    - like: string (JsonProperty: like) [Optional]
-*/
+/// A representation of the viewer's relationship with a labeler.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LabelerViewerState {
+    /// The URI of the like record.
     like: Option<String>
 }
 
-/*    Type: labelerPolicies
-    Id: app.bsky.labeler.defs#labelerPolicies
-    Kind: object
-
-    Properties:
-    - label_values: com.atproto.label.defs#labelValue[] (JsonProperty: labelValues) [Required]
-    - label_value_definitions: com.atproto.label.defs#labelValueDefinition[] (JsonProperty: labelValueDefinitions) [Optional]
-*/
+/// Policies for a labeler.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LabelerPolicies {
+    /// The label values of the labeler.
     label_values: Vec<String>,
+
+    /// The label value definitions of the labeler.
     label_value_definitions: Option<Vec<LabelValueDefinition>>
 }

--- a/atprotolib-rs/src/types/app_bsky/labeler/get_services.rs
+++ b/atprotolib-rs/src/types/app_bsky/labeler/get_services.rs
@@ -6,20 +6,19 @@ use super::{LabelerView, LabelerViewDetailed};
     app.bsky.labeler.getServices
 */
 
-/*    Type: response
-    Id: app.bsky.labeler.getServices#response
-    Kind: object
-
-    Properties:
-    - views: union[] (JsonProperty: views) [Required]
-*/
+/// The response to a request getting services for a labeler.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetServicesResponse {
+    /// The views.
     views: Vec<LabelerViewDetailed>
 }
 
+/// A type union for the views in the response.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum GetServicesResponseViews {
+    /// A view of a labeler.
     LabelerView(LabelerView),
+
+    /// A detailed view of a labeler.
     LabelerViewDetailed(LabelerViewDetailed)
 }

--- a/atprotolib-rs/src/types/app_bsky/mod.rs
+++ b/atprotolib-rs/src/types/app_bsky/mod.rs
@@ -1,3 +1,4 @@
+/// Contains types for the `app.bsky.actor` namespace.
 pub mod actor {
     mod defs;
     mod get_profiles;
@@ -20,6 +21,7 @@ pub mod actor {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `app.bsky.embed` namespace.
 pub mod embed {
     mod defs;
     mod external;
@@ -31,6 +33,7 @@ pub mod embed {
     pub use self::{defs::*, external::*, images::*, record::*, record_with_media::*, video::*};
 }
 
+/// Contains types for the `app.bsky.feed` namespace.
 pub mod feed {
     mod defs;
     mod describe_feed_generator;
@@ -87,6 +90,7 @@ pub mod feed {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `app.bsky.graph` namespace.
 pub mod graph {
     mod defs;
     mod get_actor_starter_packs;
@@ -145,6 +149,7 @@ pub mod graph {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `app.bsky.labeler` namespace.
 pub mod labeler {
     mod defs;
     mod get_services;
@@ -152,6 +157,7 @@ pub mod labeler {
     pub use self::{defs::*, get_services::*};
 }
 
+/// Contains types for the `app.bsky.notification` namespace.
 pub mod notification {
     mod get_unread_count;
     mod list_notifications;
@@ -168,12 +174,14 @@ pub mod notification {
     };
 }
 
+/// Contains types for the `app.bsky.richtext` namespace.
 pub mod richtext {
     mod facet;
 
     pub use self::facet::*;
 }
 
+/// Contains types for the `app.bsky.video` namespace.
 pub mod video {
     mod defs;
     mod get_job_status;

--- a/atprotolib-rs/src/types/app_bsky/notification/get_unread_count.rs
+++ b/atprotolib-rs/src/types/app_bsky/notification/get_unread_count.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     app.bsky.notification.getUnreadCount
 */
 
-/*    Type: response
-    Id: app.bsky.notification.getUnreadCount#response
-    Kind: object
-
-    Properties:
-    - count: integer  (JsonProperty: count) [Required]
-*/
+/// The response to a request for the unread count of notifications.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetUnreadCountResponse {
+    /// The count of unread notifications.
     #[serde(rename = "count", default)]
     pub count: i32
 }

--- a/atprotolib-rs/src/types/app_bsky/notification/list_notifications.rs
+++ b/atprotolib-rs/src/types/app_bsky/notification/list_notifications.rs
@@ -7,57 +7,58 @@ use crate::types::{app_bsky::actor::ProfileView, com_atproto::label::Label};
     app.bsky.notification.listNotifications
 */
 
-/*    Type: response
-    Id: app.bsky.notification.listNotifications#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - notifications: #notification[] (JsonProperty: notifications) [Required]
-    - priority: boolean  (JsonProperty: priority) [Optional]
-    - seen_at: datetime (JsonProperty: seenAt) [Optional]
-*/
+/// The response to a request for a user's notifications.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListNotificationsResponse {
+    /// The cursor for the stream.
     cursor: Option<String>,
+
+    /// A list of the user's notifications.
     notifications: Vec<Notification>,
+
+    /// Whether the notifications are priority notifications.
     priority: bool,
+
+    /// The date and time the notifications were last seen.
     seen_at: Option<DateTime<Utc>>
 }
 
-/*    Type: notification
-    Id: app.bsky.notification.listNotifications#notification
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - author: app.bsky.actor.defs#profileView (JsonProperty: author) [Required]
-    - reason: string (JsonProperty: reason) [Required]
-    - reason_subject: string (JsonProperty: reasonSubject) [Optional]
-    - record: unknown  (JsonProperty: record) [Required]
-    - is_read: boolean  (JsonProperty: isRead) [Required]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Optional]
-*/
+/// Represents a notification.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Notification {
+    /// The URI of the notification.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The CID of the notification.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The author of the notification.
     #[serde(rename = "author")]
     pub author: ProfileView,
+
+    /// The reason for the notification.
     #[serde(rename = "reason")]
     pub reason: String,
+
+    /// The subject of the reason.
     #[serde(rename = "reasonSubject", skip_serializing_if = "Option::is_none")]
     pub reason_subject: Option<String>,
+    
+    /// The record associated with the notification.
     #[serde(rename = "record")]
     pub record: serde_json::Value,
+
+    /// Whether the notification has been read.
     #[serde(rename = "isRead", default)]
     pub is_read: bool,
+
+    /// The date and time the notification was indexed.
     #[serde(rename = "indexedAt")]
     pub indexed_at: DateTime<Utc>,
+
+    /// Labels associated with the notification.
     #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>
 }

--- a/atprotolib-rs/src/types/app_bsky/notification/put_preferences.rs
+++ b/atprotolib-rs/src/types/app_bsky/notification/put_preferences.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     app.bsky.notification.putPreferences
 */
 
-/*    Type: request
-    Id: app.bsky.notification.putPreferences#request
-    Kind: object
-
-    Properties:
-    - priority: boolean  (JsonProperty: priority) [Required]
-*/
+/// The request to update the user's notification preferences.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PutPreferencesRequest {
+    /// Whether to enable only priority notifications.
     #[serde(rename = "priority", default)]
     pub priority: bool
 }

--- a/atprotolib-rs/src/types/app_bsky/notification/register_push.rs
+++ b/atprotolib-rs/src/types/app_bsky/notification/register_push.rs
@@ -4,24 +4,22 @@ use serde::{Deserialize, Serialize};
     app.bsky.notification.registerPush
 */
 
-/*    Type: request
-    Id: app.bsky.notification.registerPush#request
-    Kind: object
-
-    Properties:
-    - service_did: string (JsonProperty: serviceDid) [Required]
-    - token: string (JsonProperty: token) [Required]
-    - platform: string (JsonProperty: platform) [Required]
-    - app_id: string (JsonProperty: appId) [Required]
-*/
+/// The request to register a push notification token.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RegisterPushRequest {
+    /// The service DID.
     #[serde(rename = "serviceDid")]
     pub service_did: String,
+
+    /// The push notification token.
     #[serde(rename = "token")]
     pub token: String,
+
+    /// The platform of the push notification token.
     #[serde(rename = "platform")]
     pub platform: String,
+
+    /// The app ID.
     #[serde(rename = "appId")]
     pub app_id: String
 }

--- a/atprotolib-rs/src/types/app_bsky/notification/update_seen.rs
+++ b/atprotolib-rs/src/types/app_bsky/notification/update_seen.rs
@@ -5,15 +5,10 @@ use serde::{Deserialize, Serialize};
     app.bsky.notification.updateSeen
 */
 
-/*    Type: request
-    Id: app.bsky.notification.updateSeen#request
-    Kind: object
-
-    Properties:
-    - seen_at: datetime (JsonProperty: seenAt) [Required]
-*/
+/// The request to update the time at which notifications were seen.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateSeenRequest {
+    /// The date and time when the notification was seen at.
     #[serde(rename = "seenAt")]
     pub seen_at: DateTime<Utc>
 }

--- a/atprotolib-rs/src/types/app_bsky/richtext/facet.rs
+++ b/atprotolib-rs/src/types/app_bsky/richtext/facet.rs
@@ -4,86 +4,68 @@ use serde::{Deserialize, Serialize};
     app.bsky.richtext.facet
 */
 
-/*
-    Type: RichTextFacet
-    Id: app.bsky.richtext.facet#main
-    Kind: object
-
-    Properties:
-    - index: #byteSlice (JsonProperty: index) [Required]
-    - features: union[] (JsonProperty: features) [Required]
-*/
+/// Represents a facet of rich text.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.richtext.facet")]
 pub struct RichTextFacet {
+    /// The index of the facet in the rich text.
     #[serde(rename = "index")]
     index: ByteSlice,
+
+    /// The features of the facet.
     #[serde(rename = "features")]
     features: Vec<RichTextFacetFeatures>
 }
 
+/// A type union for the features of a rich text facet.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum RichTextFacetFeatures {
+    /// A mention.
     Mention(Mention),
+
+    /// A link.
     Link(Link),
+
+    /// A tag.
     Tag(Tag)
 }
 
-/*    Type: mention
-    Id: app.bsky.richtext.facet#mention
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-*/
+/// Represents a mention in a rich text facet.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.richtext.facet#mention")]
 pub struct Mention {
+    /// The DID of the mention.
     #[serde(rename = "did")]
     did: String
 }
 
-/*    Type: link
-    Id: app.bsky.richtext.facet#link
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-*/
+/// Represents a link in a rich text facet.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.richtext.facet#link")]
 pub struct Link {
+    /// The URI of the link.
     #[serde(rename = "uri")]
     uri: String
 }
 
-/*    Type: tag
-    Id: app.bsky.richtext.facet#tag
-    Kind: object
-
-    Properties:
-    - tag: string (JsonProperty: tag) [Required]
-*/
+/// Represents a tag in a rich text facet.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.richtext.facet#tag")]
 pub struct Tag {
+    /// The tag.
     #[serde(rename = "tag")]
     tag: String
 }
 
-/*    Type: byteSlice
-    Id: app.bsky.richtext.facet#byteSlice
-    Kind: object
-
-    Properties:
-    - byte_start: integer  (JsonProperty: byteStart) [Required]
-    - byte_end: integer  (JsonProperty: byteEnd) [Required]
-*/
+/// Represents a byte slice.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.richtext.facet#byteSlice")]
 pub struct ByteSlice {
+    /// The start byte.
     #[serde(rename = "byteStart")]
     byte_start: i64,
+
+    /// The end byte.
     #[serde(rename = "byteEnd")]
     byte_end: i64
 }

--- a/atprotolib-rs/src/types/app_bsky/video/api_calls.rs
+++ b/atprotolib-rs/src/types/app_bsky/video/api_calls.rs
@@ -3,6 +3,15 @@ use crate::{
     types::app_bsky
 };
 
+/// Get status details for a video processing job.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The hostname of the server to connect to.
+/// * `api_auth_config` - The authentication configuration to use.
+/// * `job_id` - The ID of the job to get the status of.
 pub async fn get_job_status(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -30,6 +39,14 @@ pub async fn get_job_status(
     }
 }
 
+/// Get video upload limits for the authenticated user.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The hostname of the server to connect to.
+/// * `api_auth_config` - The authentication configuration to use.
 pub async fn get_upload_limits(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -53,6 +70,15 @@ pub async fn get_upload_limits(
     }
 }
 
+/// Upload a video to be processed then stored on the PDS.
+/// 
+/// <div class="warning">Requires the <code>apicalls</code> feature.</div>
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The hostname of the server to connect to.
+/// * `api_auth_config` - The authentication configuration to use.
+/// * `video` - The video to upload.
 pub async fn upload_video(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/app_bsky/video/defs.rs
+++ b/atprotolib-rs/src/types/app_bsky/video/defs.rs
@@ -1,33 +1,34 @@
 use serde::{Deserialize, Serialize};
 
-/*    Type: jobStatus
-    Id: app.bsky.video.defs#jobStatus
-    Kind: object
-
-    Properties:
-    - job_id: string (JsonProperty: jobId) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - state: string (JsonProperty: state) [Required]
-    - progress: integer  (JsonProperty: progress) [Optional]
-    - blob: blob  (JsonProperty: blob) [Optional]
-    - error: string (JsonProperty: error) [Optional]
-    - message: string (JsonProperty: message) [Optional]
-*/
+/// Represents the status of a video upload job.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "app.bsky.video.defs#jobStatus")]
 pub struct JobStatus {
+    /// The ID of the job.
     #[serde(rename = "jobId")]
     pub job_id: String,
+
+    /// The DID of the job.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The state of the job.
     #[serde(rename = "state")]
     pub state: String,
+
+    /// The progress of the job.
     #[serde(rename = "progress", default)]
     pub progress: i32,
+
+    /// The blob of the job.
     #[serde(rename = "blob", skip_serializing_if = "Option::is_none")]
     pub blob: Option<Vec<u8>>,
+
+    /// The error of the job.
     #[serde(rename = "error", skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+
+    /// The message of the job.
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>
 }

--- a/atprotolib-rs/src/types/app_bsky/video/get_job_status.rs
+++ b/atprotolib-rs/src/types/app_bsky/video/get_job_status.rs
@@ -6,15 +6,10 @@ use super::JobStatus;
     app.bsky.video.getJobStatus
 */
 
-/*    Type: response
-    Id: app.bsky.video.getJobStatus#response
-    Kind: object
-
-    Properties:
-    - job_status: app.bsky.video.defs#jobStatus (JsonProperty: jobStatus) [Required]
-*/
+/// The response to a request for the status of a video upload job.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetJobStatusResponse {
+    /// The status of the job.
     #[serde(rename = "jobStatus")]
     pub job_status: JobStatus
 }

--- a/atprotolib-rs/src/types/app_bsky/video/get_upload_limits.rs
+++ b/atprotolib-rs/src/types/app_bsky/video/get_upload_limits.rs
@@ -4,27 +4,26 @@ use serde::{Deserialize, Serialize};
     app.bsky.video.getUploadLimits
 */
 
-/*    Type: response
-    Id: app.bsky.video.getUploadLimits#response
-    Kind: object
-
-    Properties:
-    - can_upload: boolean  (JsonProperty: canUpload) [Required]
-    - remaining_daily_videos: integer  (JsonProperty: remainingDailyVideos) [Optional]
-    - remaining_daily_bytes: integer  (JsonProperty: remainingDailyBytes) [Optional]
-    - message: string (JsonProperty: message) [Optional]
-    - error: string (JsonProperty: error) [Optional]
-*/
+/// The response to a request for the upload limits of a PDS.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetUploadLimitsResponse {
+    /// Whether the user can upload a video.
     #[serde(rename = "canUpload", default)]
     pub can_upload: bool,
+
+    /// The remaining daily video uploads.
     #[serde(rename = "remainingDailyVideos", default)]
     pub remaining_daily_videos: i32,
+
+    /// The remaining daily bytes of video uploads.
     #[serde(rename = "remainingDailyBytes", default)]
     pub remaining_daily_bytes: i32,
+
+    /// A message about the upload limits.
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+
+    /// An error message.
     #[serde(rename = "error", skip_serializing_if = "Option::is_none")]
     pub error: Option<String>
 }

--- a/atprotolib-rs/src/types/app_bsky/video/upload_video.rs
+++ b/atprotolib-rs/src/types/app_bsky/video/upload_video.rs
@@ -6,15 +6,10 @@ use super::JobStatus;
     app.bsky.video.uploadVideo
 */
 
-/*    Type: response
-    Id: app.bsky.video.uploadVideo#response
-    Kind: object
-
-    Properties:
-    - job_status: app.bsky.video.defs#jobStatus (JsonProperty: jobStatus) [Required]
-*/
+/// The response to a request to upload a video.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UploadVideoResponse {
+    /// The status of the job.
     #[serde(rename = "jobStatus")]
     pub job_status: JobStatus
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/api_calls.rs
@@ -21,6 +21,13 @@ use crate::{
     }
 };
 
+/// Delete a user account as an administrator.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to delete an account.
 pub async fn delete_account(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -44,6 +51,13 @@ pub async fn delete_account(
     }
 }
 
+/// Disable an account from receiving new invite codes, but does not invalidate existing codes.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to disable account invites.
 pub async fn disable_account_invites(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -70,6 +84,14 @@ pub async fn disable_account_invites(
     }
 }
 
+
+/// Disable some set of codes and/or all codes associated with a set of users.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to disable invite codes.
 pub async fn disable_invite_codes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -96,6 +118,13 @@ pub async fn disable_invite_codes(
     }
 }
 
+/// Re-enable an account's ability to receive invite codes.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to enable account invites.
 pub async fn enable_account_invites(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -122,6 +151,13 @@ pub async fn enable_account_invites(
     }
 }
 
+/// Get details about an account.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `did` - The DID of the account.
 pub async fn get_account_info(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -150,6 +186,13 @@ pub async fn get_account_info(
     }
 }
 
+/// Get details about some accounts.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to get account infos.
 pub async fn get_account_infos(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -179,6 +222,15 @@ pub async fn get_account_infos(
     }
 }
 
+/// Get an admin view of invite codes.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `limit` - The maximum number of invite codes to return. Defaults to 100.
+/// * `cursor` - The cursor to use for pagination.
+/// * `sort` - The sort order to use.
 pub async fn get_invite_codes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -221,18 +273,37 @@ pub async fn get_invite_codes(
     }
 }
 
+/// The subject to get the status of.
 pub enum GetSubjectStatusSubject {
+    /// The account DID.
     Account(String),
+
+    /// The record URI.
     Record(String),
+
+    /// The blob CID.
     Blob(String)
 }
 
+/// The response from getting the status of a subject.
 pub enum GetSubjectStatusResponse {
+    /// The account status.
     Account(GetSubjectStatusAccountResponse),
+
+    /// The record status.
     Record(GetSubjectStatusRecordResponse),
+
+    /// The blob status.
     Blob(GetSubjectStatusBlobResponse)
 }
 
+/// Get the service-specific admin status of a subject (account, record, or blob).
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `subject` - The subject to get the status of.
 pub async fn get_subject_status(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -278,6 +349,15 @@ pub async fn get_subject_status(
     }
 }
 
+/// Get a list of accounts that matches your search query.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `query` - The search query.
+/// * `limit` - The maximum number of accounts to return. Defaults to 10.
+/// * `cursor` - The cursor to use for pagination.
 pub async fn search_accounts(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -316,6 +396,13 @@ pub async fn search_accounts(
     }
 }
 
+/// Send an email to a user's account email address.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to send an email.
 pub async fn send_email(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -342,6 +429,13 @@ pub async fn send_email(
     }
 }
 
+/// Administrative action to update an account's email.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to update an account's email.
 pub async fn update_account_email(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -368,6 +462,13 @@ pub async fn update_account_email(
     }
 }
 
+/// Administrative action to update an account's handle.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to update an account's handle.
 pub async fn update_account_handle(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -394,6 +495,13 @@ pub async fn update_account_handle(
     }
 }
 
+/// Update the password for a user account as an administrator.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to update an account's password.
 pub async fn update_account_password(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/admin/defs.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/defs.rs
@@ -3,117 +3,107 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::com_atproto::server::InviteCode;
 
-/*    Type: statusAttr
-    Id: com.atproto.admin.defs#statusAttr
-    Kind: object
-
-    Properties:
-    - applied: boolean  (JsonProperty: applied) [Required]
-    - ref: string (JsonProperty: ref) [Optional]
-*/
+/// Represents a status attribute.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.admin.defs#statusAttr")]
 pub struct StatusAttr {
+    /// Whether the status is applied.
     #[serde(rename = "applied", default)]
     pub applied: bool,
+
+    /// The reference.
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>
 }
 
-/*    Type: accountView
-    Id: com.atproto.admin.defs#accountView
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - handle: string (JsonProperty: handle) [Required]
-    - email: string (JsonProperty: email) [Optional]
-    - related_records: unknown[] (JsonProperty: relatedRecords) [Optional]
-    - indexed_at: datetime (JsonProperty: indexedAt) [Required]
-    - invited_by: com.atproto.server.defs#inviteCode (JsonProperty: invitedBy) [Optional]
-    - invites: com.atproto.server.defs#inviteCode[] (JsonProperty: invites) [Optional]
-    - invites_disabled: boolean  (JsonProperty: invitesDisabled) [Optional]
-    - email_confirmed_at: datetime (JsonProperty: emailConfirmedAt) [Optional]
-    - invite_note: string (JsonProperty: inviteNote) [Optional]
-    - deactivated_at: datetime (JsonProperty: deactivatedAt) [Optional]
-    - threat_signatures: #threatSignature[] (JsonProperty: threatSignatures) [Optional]
-*/
+/// Represents an account view.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.admin.defs#accountView")]
 pub struct AccountView {
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The handle of the account.
     #[serde(rename = "handle")]
     pub handle: String,
+
+    /// The email associated with the account.
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+
+    /// Records related to the account.
     #[serde(rename = "relatedRecords", skip_serializing_if = "Option::is_none")]
     pub related_records: Option<Vec<serde_json::Value>>,
+
+    /// The date and time the account was indexed.
     #[serde(rename = "indexedAt")]
     pub indexed_at: DateTime<Utc>,
+
+    /// The invite code used to create the account.
     #[serde(rename = "invitedBy", skip_serializing_if = "Option::is_none")]
     pub invited_by: Option<InviteCode>,
+
+    /// Invite codes the account has.
     #[serde(rename = "invites", skip_serializing_if = "Option::is_none")]
     pub invites: Option<Vec<InviteCode>>,
+
+    /// Whether invites are disabled.
     #[serde(rename = "invitesDisabled", default)]
     pub invites_disabled: bool,
+
+    /// The date and time the account's email was confirmed.
     #[serde(rename = "emailConfirmedAt", skip_serializing_if = "Option::is_none")]
     pub email_confirmed_at: Option<DateTime<Utc>>,
+
+    /// An optional note about the invite.
     #[serde(rename = "inviteNote", skip_serializing_if = "Option::is_none")]
     pub invite_note: Option<String>,
+
+    /// The date and time the account was deactivated.
     #[serde(rename = "deactivatedAt", skip_serializing_if = "Option::is_none")]
     pub deactivated_at: Option<DateTime<Utc>>,
+
+    /// Threat signatures associated with the account.
     #[serde(rename = "threatSignatures", skip_serializing_if = "Option::is_none")]
     pub threat_signatures: Option<Vec<ThreatSignature>>
 }
 
-/*    Type: repoRef
-    Id: com.atproto.admin.defs#repoRef
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-*/
+/// A reference to a repository.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.admin.defs#repoRef")]
 pub struct RepoRef {
+    /// The DID.
     #[serde(rename = "did")]
     pub did: String
 }
 
-/*    Type: repoBlobRef
-    Id: com.atproto.admin.defs#repoBlobRef
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - record_uri: string (JsonProperty: recordUri) [Optional]
-*/
+/// A reference to a repository blob.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.admin.defs#repoBlobRef")]
 pub struct RepoBlobRef {
+    /// The DID.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The CID.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The URI for record.
     #[serde(rename = "recordUri", skip_serializing_if = "Option::is_none")]
     pub record_uri: Option<String>
 }
 
-/*    Type: threatSignature
-    Id: com.atproto.admin.defs#threatSignature
-    Kind: object
-
-    Properties:
-    - property: string (JsonProperty: property) [Required]
-    - value: string (JsonProperty: value) [Required]
-*/
+/// Represents a threat signature.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.admin.defs#threatSignature")]
 pub struct ThreatSignature {
+    /// The property name of the threat signature.
     #[serde(rename = "property")]
     pub property: String,
+
+    /// The value of the threat signature.
     #[serde(rename = "value")]
     pub value: String
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/delete_account.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/delete_account.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.deleteAccount#request`](https://docs.bsky.app/docs/api/com-atproto-admin-delete-account#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeleteAccountRequest {
+    /// The DID of the account to delete.
     #[serde(rename = "did")]
     pub did: String
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/disable_account_invites.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/disable_account_invites.rs
@@ -9,10 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.disableAccountInvites#request`](https://docs.bsky.app/docs/api/com-atproto-admin-disable-account-invites#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DisableAccountInvitesRequest {
+    /// The DID of the account.
     #[serde(rename = "account")]
     pub account: String,
 
-    /// Optional reason for disabled invites
+    /// Optional reason for disabled invites.
     #[serde(rename = "note", skip_serializing_if = "Option::is_none")]
     pub note: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/disable_invite_codes.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/disable_invite_codes.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.disableInviteCodes#request`](https://docs.bsky.app/docs/api/com-atproto-admin-disable-invite-codes#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DisableInviteCodesRequest {
+    /// The invite codes to disable.
     #[serde(rename = "codes", skip_serializing_if = "Option::is_none")]
     pub codes: Option<Vec<String>>,
 
+    /// The accounts to disable invite codes for.
     #[serde(rename = "accounts", skip_serializing_if = "Option::is_none")]
     pub accounts: Option<Vec<String>>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/enable_account_invites.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/enable_account_invites.rs
@@ -9,10 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.enableAccountInvites#request`](https://docs.bsky.app/docs/api/com-atproto-admin-enable-account-invites#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnableAccountInvitesRequest {
+    /// The DID of the account.
     #[serde(rename = "account")]
     pub account: String,
 
-    /// Optional reason for disabled invites
+    /// Optional reason for disabled invites.
     #[serde(rename = "note", skip_serializing_if = "Option::is_none")]
     pub note: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/get_account_info.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/get_account_info.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.getAccountInfo#request`](https://docs.bsky.app/docs/api/com-atproto-admin-get-account-info#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAccountInfoRequest {
+    /// The DID of the account to get information for.
     #[serde(rename = "did")]
     pub did: String
 }
@@ -17,6 +18,7 @@ pub struct GetAccountInfoRequest {
 /// Represents a response to a request to get account information.
 ///
 /// [`com.atproto.admin.getAccountInfo#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-account-info#responses)
+#[allow(missing_docs)] // This should be replaced with just the response being `AccountView`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAccountInfoResponse {
     #[serde(rename = "did")]
@@ -47,6 +49,7 @@ pub struct GetAccountInfoResponse {
     pub threat_signatures: Option<Vec<GetAccountInfoResponseThreatSignatures>>
 }
 
+#[allow(missing_docs)] // This should be replaced with just the response being `AccountView`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAccountInfoResponseThreatSignatures {
     #[serde(rename = "property")]

--- a/atprotolib-rs/src/types/com_atproto/admin/get_account_infos.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/get_account_infos.rs
@@ -11,6 +11,7 @@ use super::get_account_info::GetAccountInfoResponse;
 /// [`com.atproto.admin.getAccountInfos#request`](https://docs.bsky.app/docs/api/com-atproto-admin-get-account-infos#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAccountInfosRequest {
+    /// The DIDs of the accounts to get information for.
     #[serde(rename = "did")]
     pub dids: Vec<String>
 }
@@ -21,6 +22,7 @@ pub struct GetAccountInfosRequest {
 /// [`com.atproto.admin.getAccountInfos#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-account-infos#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAccountInfosResponse {
+    /// Account information for the requested accounts.
     #[serde(rename = "infos")]
     pub infos: Vec<GetAccountInfoResponse>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/get_invite_codes.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/get_invite_codes.rs
@@ -10,13 +10,16 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.getInviteCodes#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-invite-codes#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetInviteCodesResponse {
+    /// The cursor stream position.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
 
+    /// The invite codes.
     #[serde(rename = "codes")]
     pub codes: Vec<GetInviteCodesResponseCode>
 }
 
+#[allow(missing_docs)] // This should be replaced with just the response being `InviteCode`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetInviteCodesResponseCode {
     #[serde(rename = "code")]
@@ -41,6 +44,7 @@ pub struct GetInviteCodesResponseCode {
     pub uses: Vec<GetInviteCodesResponseCodeUse>
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetInviteCodesResponseCodeUse {
     #[serde(rename = "usedBy")]

--- a/atprotolib-rs/src/types/com_atproto/admin/get_subject_status.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/get_subject_status.rs
@@ -9,12 +9,15 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.getSubjectStatus#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-subject-status#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSubjectStatusAccountResponse {
+    /// The DID.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The status of the takedown request.
     #[serde(rename = "takedown")]
     pub takedown: GetSubjectStatusResponseStatus,
 
+    /// The status of the deactivation request.
     #[serde(rename = "deactivated")]
     pub deactivated: GetSubjectStatusResponseStatus
 }
@@ -24,15 +27,19 @@ pub struct GetSubjectStatusAccountResponse {
 /// [`com.atproto.admin.getSubjectStatus#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-subject-status#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSubjectStatusRecordResponse {
+    /// The URI of the record.
     #[serde(rename = "uri")]
     pub uri: String,
 
+    /// The CID of the record.
     #[serde(rename = "cid")]
     pub cid: String,
 
+    /// The status of the takedown request.
     #[serde(rename = "takedown")]
     pub takedown: GetSubjectStatusResponseStatus,
 
+    /// The status of the deactivation request.
     #[serde(rename = "deactivated")]
     pub deactivated: GetSubjectStatusResponseStatus
 }
@@ -42,27 +49,35 @@ pub struct GetSubjectStatusRecordResponse {
 /// [`com.atproto.admin.getSubjectStatus#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-get-subject-status#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSubjectStatusBlobResponse {
+    /// The DID of the blob.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The CID of the blob.
     #[serde(rename = "cid")]
     pub cid: String,
 
+    /// The URI of the record.
     #[serde(rename = "recordUri", skip_serializing_if = "Option::is_none")]
     pub record_uri: Option<String>,
 
+    /// The status of the takedown request.
     #[serde(rename = "takedown")]
     pub takedown: GetSubjectStatusResponseStatus,
 
+    /// The status of the deactivation request.
     #[serde(rename = "deactivated")]
     pub deactivated: GetSubjectStatusResponseStatus
 }
 
+/// Represents the status for a takedown or deactivation request.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetSubjectStatusResponseStatus {
+    /// Whether the request has been applied.
     #[serde(rename = "applied", default)]
     pub applied: bool,
 
+    /// The reference of the request.
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/search_accounts.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/search_accounts.rs
@@ -11,9 +11,11 @@ use super::GetAccountInfoResponse;
 /// [`com.atproto.admin.searchAccounts#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-search-accounts#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SearchAccountsResponse {
+    /// The cursor stream position.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
 
+    /// The accounts that match the search criteria.
     #[serde(rename = "accounts")]
     pub accounts: Vec<GetAccountInfoResponse>
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/send_email.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/send_email.rs
@@ -9,18 +9,23 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.sendEmail#request`](https://docs.bsky.app/docs/api/com-atproto-admin-send-email#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SendEmailRequest {
+    /// The DID of the recipient.
     #[serde(rename = "recipientDid")]
     pub recipient_did: String,
 
+    /// The content of the email.
     #[serde(rename = "content")]
     pub content: String,
 
+    /// The subject of the email.
     #[serde(rename = "subject", skip_serializing_if = "Option::is_none")]
     pub subject: Option<String>,
 
+    /// The DID of the sender.
     #[serde(rename = "senderDid")]
     pub sender_did: String,
 
+    /// An optional comment.
     #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>
 }
@@ -30,6 +35,7 @@ pub struct SendEmailRequest {
 /// [`com.atproto.admin.sendEmail#responses`](https://docs.bsky.app/docs/api/com-atproto-admin-send-email#responses)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SendEmailResponse {
+    /// Whether the email was sent.
     #[serde(rename = "sent", default)]
     pub sent: bool
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/update_account_email.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/update_account_email.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.updateAccountEmail#request`](https://docs.bsky.app/docs/api/com-atproto-admin-update-account-email#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateAccountEmailRequest {
+    /// The DID of the account.
     #[serde(rename = "account")]
     pub account: String,
 
+    /// The new email address.
     #[serde(rename = "email")]
     pub email: String
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/update_account_handle.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/update_account_handle.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.updateAccountHandle#request`](https://docs.bsky.app/docs/api/com-atproto-admin-update-account-handle#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateAccountHandleRequest {
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The new handle.
     #[serde(rename = "handle")]
     pub handle: String
 }

--- a/atprotolib-rs/src/types/com_atproto/admin/update_account_password.rs
+++ b/atprotolib-rs/src/types/com_atproto/admin/update_account_password.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.admin.updateAccountPassword#request`](https://docs.bsky.app/docs/api/com-atproto-admin-update-account-password#request)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateAccountPasswordRequest {
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The new password.
     #[serde(rename = "password")]
     pub password: String
 }

--- a/atprotolib-rs/src/types/com_atproto/identity/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/api_calls.rs
@@ -3,6 +3,12 @@ use crate::{
     types::com_atproto
 };
 
+/// Describe the credentials that should be included in the DID doc of an account that is migrating to this service.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the service.
+/// * `api_auth_config` - The API authentication configuration.
 pub async fn get_recommended_did_credentials(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -31,6 +37,13 @@ pub async fn get_recommended_did_credentials(
     }
 }
 
+/// Resolves a handle (domain name) to a DID.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the service.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `handle` - The handle to resolve.
 pub async fn resolve_handle(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -62,6 +75,13 @@ pub async fn resolve_handle(
     }
 }
 
+/// Signs a PLC operation to update some value(s) in the requesting DID's document.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the service.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to sign the PLC operation.
 pub async fn sign_plc_operation(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -91,6 +111,13 @@ pub async fn sign_plc_operation(
     }
 }
 
+/// Validates a PLC operation to ensure that it doesn't violate a service's constraints or get the identity into a bad state, then submits it to the PLC registry
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the service.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to submit the PLC operation.
 pub async fn submit_plc_operation(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -116,6 +143,13 @@ pub async fn submit_plc_operation(
     }
 }
 
+/// Updates the current account's handle. Verifies handle validity, and updates did:plc document if necessary. Implemented by PDS, and requires auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the service.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to update the handle.
 pub async fn update_handle(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/identity/get_recommended_did_credentials.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/get_recommended_did_credentials.rs
@@ -4,24 +4,22 @@ use serde::{Deserialize, Serialize};
     com.atproto.identity.getRecommendedDidCredentials
 */
 
-/*    Type: response
-    Id: com.atproto.identity.getRecommendedDidCredentials#response
-    Kind: object
-
-    Properties:
-    - rotation_keys: string[] (JsonProperty: rotationKeys) [Optional]
-    - also_known_as: string[] (JsonProperty: alsoKnownAs) [Optional]
-    - verification_methods: unknown  (JsonProperty: verificationMethods) [Optional]
-    - services: unknown  (JsonProperty: services) [Optional]
-*/
+/// Represents a response to get recommended DID credentials.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetRecommendedDidCredentialsResponse {
+    /// The rotation keys.
     #[serde(rename = "rotationKeys")]
     pub rotation_keys: Vec<String>,
+
+    /// The also known as.
     #[serde(rename = "alsoKnownAs")]
     pub also_known_as: Vec<String>,
+
+    /// The verification methods.
     #[serde(rename = "verificationMethods")]
     pub verification_methods: serde_json::Value,
+
+    /// The services.
     #[serde(rename = "services")]
     pub services: serde_json::Value
 }

--- a/atprotolib-rs/src/types/com_atproto/identity/resolve_handle.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/resolve_handle.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     com.atproto.identity.resolveHandle
 */
 
-/*    Type: response
-    Id: com.atproto.identity.resolveHandle#response
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-*/
+/// Represents a response to a request to resolve a handle to a DID.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResolveHandleResponse {
+    /// The DID associated with the handle.
     #[serde(rename = "did")]
     pub did: String
 }

--- a/atprotolib-rs/src/types/com_atproto/identity/sign_plc_operation.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/sign_plc_operation.rs
@@ -4,43 +4,37 @@ use serde::{Deserialize, Serialize};
     com.atproto.identity.signPlcOperation
 */
 
-/*    Type: request
-    Id: com.atproto.identity.signPlcOperation#request
-    Kind: object
-
-    Properties:
-    - token: string (JsonProperty: token) [Optional]
-    - rotation_keys: string[] (JsonProperty: rotationKeys) [Optional]
-    - also_known_as: string[] (JsonProperty: alsoKnownAs) [Optional]
-    - verification_methods: unknown  (JsonProperty: verificationMethods) [Optional]
-    - services: unknown  (JsonProperty: services) [Optional]
-*/
+/// Represents a request to sign a PLC operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SignPlcOperationRequest {
+    /// A token received through com.atproto.identity.requestPlcOperationSignature
     #[serde(rename = "token", skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+
+    /// The rotation keys.
     #[serde(rename = "rotationKeys", skip_serializing_if = "Option::is_none")]
     pub rotation_keys: Option<Vec<String>>,
+
+    /// The also known as.
     #[serde(rename = "alsoKnownAs", skip_serializing_if = "Option::is_none")]
     pub also_known_as: Option<Vec<String>>,
+
+    /// The verification methods.
     #[serde(
         rename = "verificationMethods",
         skip_serializing_if = "Option::is_none"
     )]
     pub verification_methods: Option<serde_json::Value>,
+
+    /// The services.
     #[serde(rename = "services", skip_serializing_if = "Option::is_none")]
     pub services: Option<serde_json::Value>
 }
 
-/*    Type: response
-    Id: com.atproto.identity.signPlcOperation#response
-    Kind: object
-
-    Properties:
-    - operation: unknown  (JsonProperty: operation) [Required]
-*/
+/// Represents a response to sign a PLC operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SignPlcOperationResponse {
+    /// A value of the operation. (?)
     #[serde(rename = "operation")]
     pub operation: serde_json::Value
 }

--- a/atprotolib-rs/src/types/com_atproto/identity/submit_plc_operation.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/submit_plc_operation.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     com.atproto.identity.submitPlcOperation
 */
 
-/*    Type: request
-    Id: com.atproto.identity.submitPlcOperation#request
-    Kind: object
-
-    Properties:
-    - operation: unknown  (JsonProperty: operation) [Required]
-*/
+/// Represents a request to submit a PLC operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SubmitPlcOperationRequest {
+    /// The operation to submit.
     #[serde(rename = "operation")]
     pub operation: serde_json::Value
 }

--- a/atprotolib-rs/src/types/com_atproto/identity/update_handle.rs
+++ b/atprotolib-rs/src/types/com_atproto/identity/update_handle.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     com.atproto.identity.updateHandle
 */
 
-/*    Type: request
-    Id: com.atproto.identity.updateHandle#request
-    Kind: object
-
-    Properties:
-    - handle: string (JsonProperty: handle) [Required]
-*/
+/// Represents a request to update a handle.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateHandleRequest {
+    /// The new handle.
     #[serde(rename = "handle")]
     pub handle: String
 }

--- a/atprotolib-rs/src/types/com_atproto/label/defs.rs
+++ b/atprotolib-rs/src/types/com_atproto/label/defs.rs
@@ -1,119 +1,109 @@
 use serde::{Deserialize, Serialize};
 
-/*    Type: label
-    Id: com.atproto.label.defs#label
-    Kind: object
-
-    Properties:
-    - ver: integer  (JsonProperty: ver) [Optional]
-    - src: string (JsonProperty: src) [Required]
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Optional]
-    - val: string (JsonProperty: val) [Required]
-    - neg: boolean  (JsonProperty: neg) [Optional]
-    - cts: datetime (JsonProperty: cts) [Required]
-    - exp: datetime (JsonProperty: exp) [Optional]
-    - sig: bytes  (JsonProperty: sig) [Optional]
-*/
+/// Metadata tag on an atproto resource (eg, repo or record).
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.label.defs#label")]
 pub struct Label {
+    /// The AT Protocol version of the label object.
     #[serde(rename = "ver", default)]
     pub ver: i32,
+
+    /// DID of the actor who created this label.
     #[serde(rename = "src")]
     pub src: String,
+
+    /// AT URI of the record, repository (account), or other resource that this label applies to.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// CID specifying the specific version of 'uri' resource this label applies to.
     #[serde(rename = "cid", skip_serializing_if = "Option::is_none")]
     pub cid: Option<String>,
+
+    /// The short string name of the value or type of this label.
     #[serde(rename = "val")]
     pub val: String,
+
+    /// Whether this label negates another label.
     #[serde(rename = "neg", default)]
     pub neg: bool,
+
+    /// Date and time the label was created.
     #[serde(rename = "cts")]
     pub cts: String,
+
+    /// Date and time the label will expire.
     #[serde(rename = "exp", skip_serializing_if = "Option::is_none")]
     pub exp: Option<String>,
+
+    /// Signature of dag-cbor encoded label.
     #[serde(rename = "sig", skip_serializing_if = "Option::is_none")]
     pub sig: Option<Vec<u8>>
 }
 
-/*    Type: selfLabels
-    Id: com.atproto.label.defs#selfLabels
-    Kind: object
-
-    Properties:
-    - values: #selfLabel[] (JsonProperty: values) [Required]
-*/
+/// Metadata tags on an atproto record, published by the author within the record.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.label.defs#selfLabels")]
 pub struct SelfLabels {
+    /// A list of self labels.
     #[serde(rename = "values")]
     pub values: Vec<SelfLabel>
 }
 
-/*    Type: selfLabel
-    Id: com.atproto.label.defs#selfLabel
-    Kind: object
-
-    Properties:
-    - val: string (JsonProperty: val) [Required]
-*/
+/// Metadata tag on an atproto record, published by the author within the record.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.label.defs#selfLabel")]
 pub struct SelfLabel {
+    /// The short string name of the value or type of this label.
     #[serde(rename = "val")]
     pub val: String
 }
 
-/*    Type: labelValueDefinition
-    Id: com.atproto.label.defs#labelValueDefinition
-    Kind: object
-
-    Properties:
-    - identifier: string (JsonProperty: identifier) [Required]
-    - severity: string (JsonProperty: severity) [Required]
-    - blurs: string (JsonProperty: blurs) [Required]
-    - default_setting: string (JsonProperty: defaultSetting) [Optional]
-    - adult_only: boolean  (JsonProperty: adultOnly) [Optional]
-    - locales: #labelValueDefinitionStrings[] (JsonProperty: locales) [Required]
-*/
+/// Declares a label value and its expected interpretations and behaviors
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.label.defs#labelValueDefinition")]
 pub struct LabelValueDefinition {
+    /// The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).
     #[serde(rename = "identifier")]
     pub identifier: String,
+
+    /// How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing.
     #[serde(rename = "severity")]
     pub severity: String,
+
+    /// What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing.
     #[serde(rename = "blurs")]
     pub blurs: String,
+
+    /// The default setting for this label.
     #[serde(rename = "defaultSetting", skip_serializing_if = "Option::is_none")]
     pub default_setting: Option<String>,
+
+    /// Does the user need to have adult content enabled in order to configure this label?
     #[serde(rename = "adultOnly", default)]
     pub adult_only: bool,
+
+    /// Locale specific display strings for the label.
     #[serde(rename = "locales")]
     pub locales: Vec<LabelValueDefinitionStrings>
 }
 
-/*    Type: labelValueDefinitionStrings
-    Id: com.atproto.label.defs#labelValueDefinitionStrings
-    Kind: object
-
-    Properties:
-    - lang: string (JsonProperty: lang) [Required]
-    - name: string (JsonProperty: name) [Required]
-    - description: string (JsonProperty: description) [Required]
-*/
+/// Strings which describe the label in the UI, localized into a specific language.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(
     tag = "$type",
     rename = "com.atproto.label.defs#labelValueDefinitionStrings"
 )]
 pub struct LabelValueDefinitionStrings {
+    /// The language code of the language these strings are written in.
     #[serde(rename = "lang")]
     pub lang: String,
+
+    /// A short human-readable name for the label.
     #[serde(rename = "name")]
     pub name: String,
+
+    /// A longer description of what the label means and why it might be applied.
     #[serde(rename = "description")]
     pub description: String
 }

--- a/atprotolib-rs/src/types/com_atproto/label/query_labels.rs
+++ b/atprotolib-rs/src/types/com_atproto/label/query_labels.rs
@@ -6,18 +6,14 @@ use super::Label;
     com.atproto.label.queryLabels
 */
 
-/*    Type: response
-    Id: com.atproto.label.queryLabels#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Required]
-*/
+/// Represents a response to a request to query labels.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QueryLabelsResponse {
+    /// The cursor stream position.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// The labels that match the query criteria.
     #[serde(rename = "labels")]
     pub labels: Vec<Label>
 }

--- a/atprotolib-rs/src/types/com_atproto/label/subscribe_labels.rs
+++ b/atprotolib-rs/src/types/com_atproto/label/subscribe_labels.rs
@@ -6,14 +6,7 @@ use super::Label;
     com.atproto.label.subscribeLabels
 */
 
-/*    Type: labels
-    Id: com.atproto.label.subscribeLabels#labels
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - labels: com.atproto.label.defs#label[] (JsonProperty: labels) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Labels {
     #[serde(rename = "seq")]
@@ -22,14 +15,7 @@ pub struct Labels {
     pub labels: Vec<Label>
 }
 
-/*    Type: info
-    Id: com.atproto.label.subscribeLabels#info
-    Kind: object
-
-    Properties:
-    - name: string (JsonProperty: name) [Required]
-    - message: string (JsonProperty: message) [Optional]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Info {
     #[serde(rename = "name")]

--- a/atprotolib-rs/src/types/com_atproto/mod.rs
+++ b/atprotolib-rs/src/types/com_atproto/mod.rs
@@ -1,3 +1,4 @@
+/// Contains types for the `com.atproto.admin` namespace.
 pub mod admin {
     mod defs;
     mod delete_account;
@@ -39,6 +40,7 @@ pub mod admin {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `com.atproto.identity` namespace.
 pub mod identity {
     mod get_recommended_did_credentials;
     mod resolve_handle;
@@ -61,6 +63,7 @@ pub mod identity {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `com.atproto.label` namespace.
 pub mod label {
     mod defs;
     mod query_labels;
@@ -69,6 +72,7 @@ pub mod label {
     pub use self::{defs::*, query_labels::*, subscribe_labels::*};
 }
 
+/// Contains types for the `com.atproto.moderation` namespace.
 pub mod moderation {
     mod create_report;
 
@@ -81,6 +85,7 @@ pub mod moderation {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `com.atproto.repo` namespace.
 pub mod repo {
     mod apply_writes;
     mod create_record;
@@ -113,6 +118,7 @@ pub mod repo {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `com.atproto.server` namespace.
 pub mod server {
     mod check_account_status;
     mod confirm_email;
@@ -169,6 +175,7 @@ pub mod server {
     pub use self::api_calls::*;
 }
 
+/// Contains types for the `com.atproto.sync` namespace.
 pub mod sync {
     mod get_head;
     mod get_latest_commit;

--- a/atprotolib-rs/src/types/com_atproto/moderation/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/moderation/api_calls.rs
@@ -3,6 +3,13 @@ use crate::{
     types::com_atproto
 };
 
+/// Submit a moderation report regarding an atproto account or record. Implemented by moderation services (with PDS proxying), and requires auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `report` - The report to create.
 pub async fn create_report(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/moderation/create_report.rs
+++ b/atprotolib-rs/src/types/com_atproto/moderation/create_report.rs
@@ -7,55 +7,58 @@ use crate::types::com_atproto::{admin::RepoRef, repo::StrongRef};
     com.atproto.moderation.createReport
 */
 
-/*    Type: request
-    Id: com.atproto.moderation.createReport#request
-    Kind: object
-
-    Properties:
-    - reason_type: com.atproto.moderation.defs#reasonType (JsonProperty: reasonType) [Required]
-    - reason: string (JsonProperty: reason) [Optional]
-    - subject: union  (JsonProperty: subject) [Required]
-*/
+/// Represents a request to create a report.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateReportRequest {
+    // TODO: Incorrect type for `reasonType`
+    /// The type of reason for the report.
     #[serde(rename = "reasonType")]
     pub reason_type: String,
+
+    /// The reason for the report.
     #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+
+    /// The subject of the report.
     #[serde(rename = "subject")]
     pub subject: CreateReportRequestSubject
 }
 
+/// Represents the subject of a report.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum CreateReportRequestSubject {
+    /// A repository reference.
     RepoRef(RepoRef),
+
+    /// A strong reference.
     StrongRef(StrongRef)
 }
 
-/*    Type: response
-    Id: com.atproto.moderation.createReport#response
-    Kind: object
-
-    Properties:
-    - id: integer  (JsonProperty: id) [Required]
-    - reason_type: com.atproto.moderation.defs#reasonType (JsonProperty: reasonType) [Required]
-    - reason: string (JsonProperty: reason) [Optional]
-    - subject: union  (JsonProperty: subject) [Required]
-    - reported_by: string (JsonProperty: reportedBy) [Required]
-    - created_at: datetime (JsonProperty: createdAt) [Required]
-*/
+/// Represents a response to a request to create a report.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateReportResponse {
+    /// The ID of the report.
     #[serde(rename = "id")]
     pub id: i64,
+
+    // TODO: Incorrect type for `reasonType`
+    /// The type of reason for the report.
     #[serde(rename = "reasonType")]
     pub reason_type: String,
+
+    /// The reason for the report.
     #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+
+    /// The subject of the report.
     #[serde(rename = "subject")]
     pub subject: serde_json::Value,
+
+    /// The account that reported the subject.
     #[serde(rename = "reportedBy")]
     pub reported_by: String,
+
+    /// The date and time the report was created.
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>
 }

--- a/atprotolib-rs/src/types/com_atproto/repo/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/api_calls.rs
@@ -3,6 +3,13 @@ use crate::{
     types::com_atproto::repo::{ApplyWritesRequest, ApplyWritesResponse}
 };
 
+/// Apply a batch transaction of repository creates, updates, and deletes. Requires auth, implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `request` - The writes to apply.
 pub async fn apply_writes(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/repo/apply_writes.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/apply_writes.rs
@@ -7,93 +7,104 @@ use crate::types::app_bsky;
     com.atproto.repo.applyWrites
 */
 
-/*    Type: request
-    Id: com.atproto.repo.applyWrites#request
-    Kind: object
-
-    Properties:
-    - repo: string (JsonProperty: repo) [Required]
-    - validate: boolean  (JsonProperty: validate) [Optional]
-    - writes: union[] (JsonProperty: writes) [Required]
-    - swap_commit: string (JsonProperty: swapCommit) [Optional]
-*/
+/// Represents a request to apply writes.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApplyWritesRequest {
+    /// The handle or DID of the repo (aka, current account).
     #[serde(rename = "repo")]
     pub repo: String,
+
+    /// Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.
     #[serde(rename = "validate", default)]
     pub validate: bool,
+
+    /// The writes to apply.
     #[serde(rename = "writes")]
     pub writes: Vec<ApplyWritesRequestWrites>,
+
+    /// If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.
     #[serde(rename = "swapCommit", skip_serializing_if = "Option::is_none")]
     pub swap_commit: Option<String>
 }
 
+/// Represents the type of write to apply.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type")]
 pub enum ApplyWritesRequestWrites {
+    /// Create a new record.
     #[serde(rename = "com.atproto.repo.applyWrites#create")]
     Create(Create),
+
+    /// Update an existing record.
     #[serde(rename = "com.atproto.repo.applyWrites#update")]
     Update(Update),
+
+    /// Delete an existing record.
     #[serde(rename = "com.atproto.repo.applyWrites#delete")]
     Delete(Delete)
 }
 
-/*    Type: response
-    Id: com.atproto.repo.applyWrites#response
-    Kind: object
-
-    Properties:
-    - commit: com.atproto.repo.defs#commitMeta (JsonProperty: commit) [Optional]
-    - results: union[] (JsonProperty: results) [Optional]
-*/
+/// Represents a response to a request to apply writes.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApplyWritesResponse {
+    /// The commit metadata.
     #[serde(rename = "commit", skip_serializing_if = "Option::is_none")]
     pub commit: Option<CommitMeta>,
+
+    /// The results of the writes.
     #[serde(rename = "results", skip_serializing_if = "Option::is_none")]
     pub results: Option<Vec<ApplyWritesResponseResults>>
 }
 
+/// Represents the results of the writes.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type")]
 pub enum ApplyWritesResponseResults {
+    /// The result of a create operation.
     #[serde(rename = "com.atproto.repo.applyWrites#createResult")]
     CreateResult(CreateResult),
+
+    /// The result of an update operation.
     #[serde(rename = "com.atproto.repo.applyWrites#updateResult")]
     UpdateResult(UpdateResult),
+
+    /// The result of a delete operation.
     #[serde(rename = "com.atproto.repo.applyWrites#deleteResult")]
     DeleteResult(DeleteResult)
 }
 
+/// Represents the different types of values that can be written.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type")]
 pub enum ApplyWritesValue {
+    /// A post.
     #[serde(rename = "app.bsky.feed.post")]
     Post(app_bsky::feed::Post)
 }
 
-/*    Type: create
-    Id: com.atproto.repo.applyWrites#create
-    Kind: object
-
-    Properties:
-    - collection: string (JsonProperty: collection) [Required]
-    - rkey: string (JsonProperty: rkey) [Optional]
-    - value: unknown  (JsonProperty: value) [Required]
-*/
+/// Represents a "create" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Create {
+    /// The collection to create the record in.
     #[serde(rename = "collection")]
     pub collection: String,
+
+    /// The record key.
     #[serde(rename = "rkey", skip_serializing_if = "Option::is_none")]
     pub rkey: Option<String>,
+
+    /// The value to create.
     #[serde(rename = "value")]
     pub value: ApplyWritesValue
 }
 
 impl Create {
+    /// Creates a new `Create` struct.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `collection` - The collection to create the record in.
+    /// * `value` - The value to create.
     pub fn new(
         collection: &str,
         value: ApplyWritesValue
@@ -106,26 +117,30 @@ impl Create {
     }
 }
 
-/*    Type: update
-    Id: com.atproto.repo.applyWrites#update
-    Kind: object
-
-    Properties:
-    - collection: string (JsonProperty: collection) [Required]
-    - rkey: string (JsonProperty: rkey) [Required]
-    - value: unknown  (JsonProperty: value) [Required]
-*/
+/// Represents an "update" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Update {
+    /// The collection to update the record in.
     #[serde(rename = "collection")]
     pub collection: String,
+
+    /// The record key.
     #[serde(rename = "rkey")]
     pub rkey: String,
+
+    /// The value to update.
     #[serde(rename = "value")]
     pub value: ApplyWritesValue
 }
 
 impl Update {
+    /// Creates a new `Update` struct.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `collection` - The collection to update the record in.
+    /// * `rkey` - The record key.
+    /// * `value` - The value to update.
     pub fn new(
         collection: &str,
         rkey: &str,
@@ -139,23 +154,25 @@ impl Update {
     }
 }
 
-/*    Type: delete
-    Id: com.atproto.repo.applyWrites#delete
-    Kind: object
-
-    Properties:
-    - collection: string (JsonProperty: collection) [Required]
-    - rkey: string (JsonProperty: rkey) [Required]
-*/
+/// Represents a "delete" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Delete {
+    /// The collection to delete the record from.
     #[serde(rename = "collection")]
     pub collection: String,
+
+    /// The record key.
     #[serde(rename = "rkey")]
     pub rkey: String
 }
 
 impl Delete {
+    /// Creates a new `Delete` struct.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `collection` - The collection to delete the record from.
+    /// * `rkey` - The record key.
     pub fn new(
         collection: &str,
         rkey: &str
@@ -167,49 +184,38 @@ impl Delete {
     }
 }
 
-/*    Type: createResult
-    Id: com.atproto.repo.applyWrites#createResult
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - validation_status: string (JsonProperty: validationStatus) [Optional]
-*/
+/// Represents the results of a "create" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateResult {
+    /// The URI of the created record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The CID of the created record.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The validation status of the created record.
     #[serde(rename = "validationStatus", skip_serializing_if = "Option::is_none")]
     pub validation_status: Option<String>
 }
 
-/*    Type: updateResult
-    Id: com.atproto.repo.applyWrites#updateResult
-    Kind: object
-
-    Properties:
-    - uri: string (JsonProperty: uri) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-    - validation_status: string (JsonProperty: validationStatus) [Optional]
-*/
+/// Represents the results of an "update" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateResult {
+    /// The URI of the updated record.
     #[serde(rename = "uri")]
     pub uri: String,
+
+    /// The CID of the updated record.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The validation status of the updated record.
     #[serde(rename = "validationStatus", skip_serializing_if = "Option::is_none")]
     pub validation_status: Option<String>
 }
 
-/*    Type: deleteResult
-    Id: com.atproto.repo.applyWrites#deleteResult
-    Kind: object
-
-    Properties:
-*/
+/// Represents the results of a "delete" write operation.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DeleteResult {}

--- a/atprotolib-rs/src/types/com_atproto/repo/create_record.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/create_record.rs
@@ -18,6 +18,7 @@ use super::CommitMeta;
     - record: unknown  (JsonProperty: record) [Required]
     - swap_commit: string (JsonProperty: swapCommit) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateRecordRequest {
     #[serde(rename = "repo")]
@@ -44,6 +45,7 @@ pub struct CreateRecordRequest {
     - commit: com.atproto.repo.defs#commitMeta (JsonProperty: commit) [Optional]
     - validation_status: string (JsonProperty: validationStatus) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateRecordResponse {
     #[serde(rename = "uri")]

--- a/atprotolib-rs/src/types/com_atproto/repo/defs.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/defs.rs
@@ -1,36 +1,27 @@
 use serde::{Deserialize, Serialize};
 
-/*    Type: commitMeta
-    Id: com.atproto.repo.defs#commitMeta
-    Kind: object
-
-    Properties:
-    - cid: string (JsonProperty: cid) [Required]
-    - rev: string (JsonProperty: rev) [Required]
-*/
+/// Metadata for a commit.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.repo.defs#commitMeta")]
 pub struct CommitMeta {
+    /// The CID.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The revision.
     #[serde(rename = "rev")]
     pub rev: String
 }
 
-/*
-    Type: strongRef
-    Id: com.atproto.repo.strongRef
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - cid: string (JsonProperty: cid) [Required]
-*/
+/// A URI with a content-hash fingerprint.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.repo.strongRef")]
 pub struct StrongRef {
-    #[serde(rename = "did")]
-    pub did: String,
+    /// The URI of the record.
+    #[serde(rename = "uri")]
+    pub uri: String,
+
+    /// The CID of the record.
     #[serde(rename = "cid")]
     pub cid: String
 }

--- a/atprotolib-rs/src/types/com_atproto/repo/delete_record.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/delete_record.rs
@@ -17,6 +17,7 @@ use super::CommitMeta;
     - swap_record: string (JsonProperty: swapRecord) [Optional]
     - swap_commit: string (JsonProperty: swapCommit) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DeleteRecordRequest {
     #[serde(rename = "repo")]
@@ -38,6 +39,7 @@ pub struct DeleteRecordRequest {
     Properties:
     - commit: com.atproto.repo.defs#commitMeta (JsonProperty: commit) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DeleteRecordResponse {
     #[serde(rename = "commit", skip_serializing_if = "Option::is_none")]

--- a/atprotolib-rs/src/types/com_atproto/repo/describe_repo.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/describe_repo.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
     - collections: string[] (JsonProperty: collections) [Required]
     - handle_is_correct: boolean  (JsonProperty: handleIsCorrect) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DescribeRepoResponse {
     #[serde(rename = "handle")]

--- a/atprotolib-rs/src/types/com_atproto/repo/get_record.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/get_record.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
     - cid: string (JsonProperty: cid) [Optional]
     - value: unknown  (JsonProperty: value) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetRecordResponse {
     #[serde(rename = "uri")]

--- a/atprotolib-rs/src/types/com_atproto/repo/list_missing_blobs.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/list_missing_blobs.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     - cursor: string (JsonProperty: cursor) [Optional]
     - blobs: #recordBlob[] (JsonProperty: blobs) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListMissingBlobsResponse {
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
@@ -28,6 +29,7 @@ pub struct ListMissingBlobsResponse {
     - cid: string (JsonProperty: cid) [Required]
     - record_uri: string (JsonProperty: recordUri) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RecordBlob {
     #[serde(rename = "cid")]

--- a/atprotolib-rs/src/types/com_atproto/repo/list_records.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/list_records.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     - cursor: string (JsonProperty: cursor) [Optional]
     - records: #record[] (JsonProperty: records) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListRecordsResponse {
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
@@ -29,6 +30,7 @@ pub struct ListRecordsResponse {
     - cid: string (JsonProperty: cid) [Required]
     - value: unknown  (JsonProperty: value) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Record {
     #[serde(rename = "uri")]

--- a/atprotolib-rs/src/types/com_atproto/repo/put_record.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/put_record.rs
@@ -19,6 +19,7 @@ use super::CommitMeta;
     - swap_record: string (JsonProperty: swapRecord) [Optional]
     - swap_commit: string (JsonProperty: swapCommit) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PutRecordRequest {
     #[serde(rename = "repo")]
@@ -47,6 +48,7 @@ pub struct PutRecordRequest {
     - commit: com.atproto.repo.defs#commitMeta (JsonProperty: commit) [Optional]
     - validation_status: string (JsonProperty: validationStatus) [Optional]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PutRecordResponse {
     #[serde(rename = "uri")]

--- a/atprotolib-rs/src/types/com_atproto/repo/upload_blob.rs
+++ b/atprotolib-rs/src/types/com_atproto/repo/upload_blob.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
     Properties:
     - blob: blob  (JsonProperty: blob) [Required]
 */
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UploadBlobResponse {
     #[serde(rename = "blob")]

--- a/atprotolib-rs/src/types/com_atproto/server/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/api_calls.rs
@@ -27,6 +27,13 @@ use crate::{
     }
 };
 
+/// Confirm an email using a token from `com.atproto.server.requestEmailConfirmation`.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to confirm the email.
 pub async fn confirm_email(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -50,6 +57,13 @@ pub async fn confirm_email(
     }
 }
 
+/// Create an account. Implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to create the account.
 pub async fn create_account(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -79,6 +93,13 @@ pub async fn create_account(
     }
 }
 
+/// Create an App Password.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to create the App Password.
 pub async fn create_app_password(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -108,6 +129,13 @@ pub async fn create_app_password(
     }
 }
 
+/// Create an invite code.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to create the invite code.
 pub async fn create_invite_code(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -137,6 +165,13 @@ pub async fn create_invite_code(
     }
 }
 
+/// Create an authentication session.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to create the session.
 pub async fn create_session(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -166,6 +201,13 @@ pub async fn create_session(
     }
 }
 
+/// Deactivates a currently active account. Stops serving of repo, and future writes to repo until reactivated. Used to finalize account migration with the old host after the account has been activated on the new host.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to deactivate the account.
 pub async fn deactivate_account(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -192,6 +234,13 @@ pub async fn deactivate_account(
     }
 }
 
+/// Delete an actor's account with a token and password. Can only be called after requesting a deletion token. Requires auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to delete the account.
 pub async fn delete_account(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -218,6 +267,12 @@ pub async fn delete_account(
     }
 }
 
+/// Describes the server's account creation requirements and capabilities. Implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
 pub async fn describe_server(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -245,6 +300,15 @@ pub async fn describe_server(
     }
 }
 
+/// Get a signed token on behalf of the requesting DID for the requested service.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `did` - The DID of the service that the token will be used to authenticate with
+/// * `expiry` - The time in Unix Epoch seconds that the JWT expires. Defaults to 60 seconds in the future. The service may enforce certain time bounds on tokens depending on the requested scope.
+/// * `lexicon` - Lexicon (XRPC) method to bind the requested token to
 pub async fn get_service_auth(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -284,6 +348,12 @@ pub async fn get_service_auth(
     }
 }
 
+/// Get information about the current auth session. Requires auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
 pub async fn get_session(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -308,6 +378,12 @@ pub async fn get_session(
     }
 }
 
+/// List all App Passwords.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
 pub async fn list_app_passwords(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -335,6 +411,12 @@ pub async fn list_app_passwords(
     }
 }
 
+/// Refresh an authentication session. Requires auth using the 'refreshJwt' (not the 'accessJwt').
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
 pub async fn refresh_session(
     host_name: &str,
     api_auth_config: &ApiAuthConfig
@@ -362,6 +444,13 @@ pub async fn refresh_session(
     }
 }
 
+/// Request a token in order to update email.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `email` - The new email address.
 pub async fn request_email_update(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -391,6 +480,14 @@ pub async fn request_email_update(
     }
 }
 
+
+/// Initiate a user account password reset via email.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to reset the password.
 pub async fn request_password_reset(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -417,6 +514,13 @@ pub async fn request_password_reset(
     }
 }
 
+/// Reserve a repo signing key, for use with account creation. Necessary so that a DID PLC update operation can be constructed during an account migraiton. Public and does not require auth; implemented by PDS. NOTE: this endpoint may change when full account migration is implemented.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to reserve the signing key.
 pub async fn reserve_signing_key(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -446,6 +550,13 @@ pub async fn reserve_signing_key(
     }
 }
 
+/// Reset a user account password using a token.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to reset the password.
 pub async fn reset_password(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -472,6 +583,13 @@ pub async fn reset_password(
     }
 }
 
+/// Revoke an App Password by name.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to revoke the App Password.
 pub async fn revoke_app_password(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -498,6 +616,13 @@ pub async fn revoke_app_password(
     }
 }
 
+/// Update an account's email.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server.
+/// * `api_auth_config` - The API authentication configuration.
+/// * `request` - The request to update the email.
 pub async fn update_email(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/server/check_account_status.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/check_account_status.rs
@@ -17,24 +17,31 @@ pub struct CheckAccountStatusResponse {
     #[serde(rename = "validDid", default)]
     pub valid_did: bool,
 
+    /// The repo commit CID.
     #[serde(rename = "repoCommit")]
     pub repo_commit: String,
 
+    /// The repo revision.
     #[serde(rename = "repoRev")]
     pub repo_revision: String,
 
+    /// The repo blocks.
     #[serde(rename = "repoBlocks")]
     pub repo_blocks: String,
 
+    /// The count of indexed records.
     #[serde(rename = "indexedRecords", default)]
     pub indexed_records: i32,
 
+    /// The count of private state values.
     #[serde(rename = "privateStateValues", default)]
     pub private_state_values: i32,
 
+    /// The count of expected blobs.
     #[serde(rename = "publicStateValues", default)]
     pub expected_blobs: i32,
 
+    /// The count of imported blobs.
     #[serde(rename = "importedBlobs", default)]
     pub imported_blobs: i32
 }

--- a/atprotolib-rs/src/types/com_atproto/server/create_account.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/create_account.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.createAccount#request`](https://docs.bsky.app/docs/api/com-atproto-server-create-account#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateAccountRequest {
+    /// Optional email address for the account.
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
 
@@ -19,12 +20,15 @@ pub struct CreateAccountRequest {
     #[serde(rename = "did", skip_serializing_if = "Option::is_none")]
     pub did: Option<String>,
 
+    /// Optional invite code for the account.
     #[serde(rename = "inviteCode", skip_serializing_if = "Option::is_none")]
     pub invite_code: Option<String>,
 
+    /// Optional phone number for the account.
     #[serde(rename = "verificationCode", skip_serializing_if = "Option::is_none")]
     pub verification_code: Option<String>,
 
+    /// Optional phone number for the account.
     #[serde(rename = "verificationPhone", skip_serializing_if = "Option::is_none")]
     pub verification_phone: Option<String>,
 
@@ -44,12 +48,15 @@ pub struct CreateAccountRequest {
 /// [`com.atproto.server.createAccount#responses`](https://docs.bsky.app/docs/api/com-atproto-server-create-account#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateAccountResponse {
+    /// The access JWT for the new account.
     #[serde(rename = "accessJwt")]
     pub access_jwt: String,
 
+    /// The refresh JWT for the new account.
     #[serde(rename = "refreshJwt")]
     pub refresh_jwt: String,
 
+    /// The handle of the new account.
     #[serde(rename = "handle")]
     pub handle: String,
 

--- a/atprotolib-rs/src/types/com_atproto/server/create_app_password.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/create_app_password.rs
@@ -33,9 +33,11 @@ pub struct CreateAppPasswordResponse {
     #[serde(rename = "password")]
     pub password: String,
 
+    /// The date and time the app password was created.
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
 
+    /// Whether the app password has 'privileged' access to possibly sensitive account data.
     #[serde(rename = "privileged", default)]
     pub privileged: bool
 }

--- a/atprotolib-rs/src/types/com_atproto/server/create_invite_codes.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/create_invite_codes.rs
@@ -12,10 +12,15 @@ use serde::{Deserialize, Serialize};
     - account: string (JsonProperty: account) [Required]
     - codes: string[] (JsonProperty: codes) [Required]
 */
+
+/// Represents invite codes generated for an account.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AccountCodes {
+    /// The account DID.
     #[serde(rename = "account")]
     pub account: String,
+
+    /// The invite codes generated.
     #[serde(rename = "codes")]
     pub codes: Vec<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/create_session.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/create_session.rs
@@ -14,9 +14,11 @@ pub struct CreateSessionRequest {
     #[serde(rename = "identifier")]
     pub identifier: String,
 
+    /// The password of the authenticating user.
     #[serde(rename = "password")]
     pub password: String,
 
+    /// An optional token for two-factor authentication.
     #[serde(rename = "authFactorToken", skip_serializing_if = "Option::is_none")]
     pub auth_factor_token: Option<String>
 }
@@ -26,30 +28,39 @@ pub struct CreateSessionRequest {
 /// [`com.atproto.server.createSession#responses`](https://docs.bsky.app/docs/api/com-atproto-server-create-session#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateSessionResponse {
+    /// The access JWT.
     #[serde(rename = "accessJwt")]
     pub access_jwt: String,
 
+    /// The refresh JWT.
     #[serde(rename = "refreshJwt")]
     pub refresh_jwt: String,
 
+    /// The handle of the account.
     #[serde(rename = "handle")]
     pub handle: String,
 
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The email of the account.
     #[serde(rename = "email")]
     pub email: String,
 
+    /// Whether the email is confirmed.
     #[serde(rename = "emailConfirmed", default)]
     pub email_confirmed: bool,
 
+    /// Whether email is used as an authentication factor.
     #[serde(rename = "emailAuthFactor", default)]
     pub email_auth_factor: bool,
 
+    /// Whether the session is active.
     #[serde(rename = "active", default)]
     pub active: bool,
 
+    /// The status of the session.
     #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
     pub status: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/defs.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/defs.rs
@@ -1,51 +1,48 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/*    Type: inviteCode
-    Id: com.atproto.server.defs#inviteCode
-    Kind: object
-
-    Properties:
-    - code: string (JsonProperty: code) [Required]
-    - available: integer  (JsonProperty: available) [Required]
-    - disabled: boolean  (JsonProperty: disabled) [Required]
-    - for_account: string (JsonProperty: forAccount) [Required]
-    - created_by: string (JsonProperty: createdBy) [Required]
-    - created_at: datetime (JsonProperty: createdAt) [Required]
-    - uses: #inviteCodeUse[] (JsonProperty: uses) [Required]
-*/
+/// Represents an invite code.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.server.defs#inviteCode")]
 pub struct InviteCode {
+    /// The invite code.
     #[serde(rename = "code")]
     pub code: String,
+
+    /// The number of available uses.
     #[serde(rename = "available", default)]
     pub available: i32,
+
+    /// Whether the invite code is disabled.
     #[serde(rename = "disabled", default)]
     pub disabled: bool,
+
+    /// The account the invite code is for.
     #[serde(rename = "forAccount")]
     pub for_account: String,
+
+    /// The account that created the invite code.
     #[serde(rename = "createdBy")]
     pub created_by: String,
+
+    /// The date and time the invite code was created.
     #[serde(rename = "createdAt")]
-    pub created_at: String,
+    pub created_at: DateTime<Utc>,
+
+    /// The uses of the invite code.
     #[serde(rename = "uses")]
     pub uses: Vec<InviteCodeUse>
 }
 
-/*    Type: inviteCodeUse
-    Id: com.atproto.server.defs#inviteCodeUse
-    Kind: object
-
-    Properties:
-    - used_by: string (JsonProperty: usedBy) [Required]
-    - used_at: datetime (JsonProperty: usedAt) [Required]
-*/
+/// Represents an invite code use.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "$type", rename = "com.atproto.server.defs#inviteCodeUse")]
 pub struct InviteCodeUse {
+    /// The account that used the invite code.
     #[serde(rename = "usedBy")]
     pub used_by: String,
+
+    /// The date and time the invite code was used.
     #[serde(rename = "usedAt")]
     pub used_at: DateTime<Utc>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/delete_account.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/delete_account.rs
@@ -17,6 +17,7 @@ pub struct DeleteAccountRequest {
     #[serde(rename = "password")]
     pub password: String,
 
+    /// Confirmation token for the account deletion.
     #[serde(rename = "token")]
     pub token: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/describe_server.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/describe_server.rs
@@ -9,33 +9,43 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.describeServer#responses`](https://docs.bsky.app/docs/api/com-atproto-server-describe-server#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DescribeServerResponse {
+    /// Whether the server requires an invite code to join.
     #[serde(rename = "inviteCodeRequired", default)]
     pub invite_code_required: bool,
 
+    /// Whether the server requires phone verification.
     #[serde(rename = "phoneVerificationRequired", default)]
     pub phone_verification_required: bool,
 
+    /// The available user domains to use for handles.
     #[serde(rename = "availableUserDomains")]
     pub available_user_domains: Vec<String>,
 
+    /// Links to the server's privacy policy and terms of service.
     #[serde(rename = "links")]
     pub links: DescribeServerResponseLinks,
 
+    /// Contact information for the server.
     #[serde(rename = "contact")]
     pub contact: DescribeServerResponseContact
 }
 
+/// Represents links to the server's privacy policy and terms of service.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DescribeServerResponseLinks {
+    /// A link to the server's privacy policy.
     #[serde(rename = "privacyPolicy", skip_serializing_if = "Option::is_none")]
     pub privacy_policy: Option<String>,
 
+    /// A link to the server's terms of service.
     #[serde(rename = "termsOfService", skip_serializing_if = "Option::is_none")]
     pub terms_of_service: Option<String>
 }
 
+/// Represents contact information for the server.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DescribeServerResponseContact {
+    /// The email address for the contact.
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/get_account_invite_codes.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/get_account_invite_codes.rs
@@ -6,8 +6,10 @@ use super::InviteCode;
     com.atproto.server.getAccountInviteCodes
 */
 
+/// Represents a request to get account invite codes.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetAccountInviteCodesRequest {
+    /// Codes to get.
     #[serde(rename = "codes")]
     pub codes: Vec<InviteCode>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/get_service_auth.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/get_service_auth.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.getServiceAuth#responses`](https://docs.bsky.app/docs/api/com-atproto-server-get-service-auth#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetServiceAuthResponse {
+    /// The service auth token.
     #[serde(rename = "token")]
     pub token: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/get_session.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/get_session.rs
@@ -9,30 +9,39 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.getSession#request`](https://docs.bsky.app/docs/api/com-atproto-server-get-session#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetSessionResponse {
+    /// The access JWT.
     #[serde(rename = "accessJwt")]
     pub access_jwt: String,
 
+    /// The refresh JWT.
     #[serde(rename = "refreshJwt")]
     pub refresh_jwt: String,
 
+    /// The handle of the account.
     #[serde(rename = "handle")]
     pub handle: String,
 
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// The email of the account.
     #[serde(rename = "email")]
     pub email: String,
 
+    /// Whether the email is confirmed.
     #[serde(rename = "emailConfirmed", default)]
     pub email_confirmed: bool,
 
+    /// Whether email is used as an authentication factor.
     #[serde(rename = "emailAuthFactor", default)]
     pub email_auth_factor: bool,
 
+    /// Whether the session is active.
     #[serde(rename = "active", default)]
     pub active: bool,
 
+    /// The status of the session.
     #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
     pub status: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/list_app_passwords.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/list_app_passwords.rs
@@ -10,19 +10,23 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.listAppPasswords#responses`](https://docs.bsky.app/docs/api/com-atproto-server-list-app-passwords#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListAppPasswordsResponse {
+    /// The app passwords.
     #[serde(rename = "passwords")]
     pub passwords: Vec<ListAppPasswordsResponseAppPassword>
 }
 
+/// Represents an App Password.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListAppPasswordsResponseAppPassword {
     /// A short name for the App Password, to help distinguish them.
     #[serde(rename = "name")]
     pub name: String,
 
+    /// The date and time the app password was created.
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
 
+    /// If an app password has 'privileged' access to possibly sensitive account data.
     #[serde(rename = "privileged", default)]
     pub privileged: bool
 }

--- a/atprotolib-rs/src/types/com_atproto/server/refresh_session.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/refresh_session.rs
@@ -9,21 +9,27 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.refreshSession#responses`](https://docs.bsky.app/docs/api/com-atproto-server-refresh-session#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RefreshSessionResponse {
+    /// The access JWT.
     #[serde(rename = "accessJwt")]
     pub access_jwt: String,
 
+    /// The refresh JWT.
     #[serde(rename = "refreshJwt")]
     pub refresh_jwt: String,
 
+    /// The handle of the account.
     #[serde(rename = "handle")]
     pub handle: String,
 
+    /// The DID of the account.
     #[serde(rename = "did")]
     pub did: String,
 
+    /// Whether the session is active.
     #[serde(rename = "active", default)]
     pub active: bool,
 
+    /// The status of the session.
     #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
     pub status: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/server/request_email_update.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/request_email_update.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.requestEmailUpdate#responses`](https://docs.bsky.app/docs/api/com-atproto-server-request-email-update#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RequestEmailUpdateResponse {
+    /// Whether a token is required.
     #[serde(rename = "tokenRequired", default)]
     pub token_required: bool
 }

--- a/atprotolib-rs/src/types/com_atproto/server/request_password_reset.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/request_password_reset.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.requestPasswordReset#request`](https://docs.bsky.app/docs/api/com-atproto-server-request-password-reset#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RequestPasswordResetRequest {
+    /// The email of the account to reset the password for.
     #[serde(rename = "email")]
     pub email: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/reserve_signing_key.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/reserve_signing_key.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.reserveSigningKey#request`](https://docs.bsky.app/docs/api/com-atproto-server-reserve-signing-key#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ReserveSigningKeyRequest {
+    /// The DID of the account to reserve a signing key for.
     #[serde(rename = "did")]
     pub did: String
 }
@@ -18,6 +19,7 @@ pub struct ReserveSigningKeyRequest {
 /// [`com.atproto.server.reserveSigningKey#responses`](https://docs.bsky.app/docs/api/com-atproto-server-reserve-signing-key#responses)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ReserveSigningKeyResponse {
+    /// The reserved signing key.
     #[serde(rename = "signingKey")]
     pub signing_key: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/reset_password.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/reset_password.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.resetPassword#request`](https://docs.bsky.app/docs/api/com-atproto-server-reset-password#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResetPasswordRequest {
+    /// A confirmation token.
     #[serde(rename = "token")]
     pub token: String,
 
+    /// The current password.
     #[serde(rename = "password")]
     pub password: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/revoke_app_password.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/revoke_app_password.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.revokeAppPassword#request`](https://docs.bsky.app/docs/api/com-atproto-server-revoke-app-password#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RevokeAppPasswordRequest {
+    /// The name of the app password to revoke.
     #[serde(rename = "name")]
     pub name: String
 }

--- a/atprotolib-rs/src/types/com_atproto/server/update_email.rs
+++ b/atprotolib-rs/src/types/com_atproto/server/update_email.rs
@@ -9,9 +9,11 @@ use serde::{Deserialize, Serialize};
 /// [`com.atproto.server.updateEmail#request`](https://docs.bsky.app/docs/api/com-atproto-server-update-email#request)
 #[derive(Serialize, Deserialize, Debug)]
 pub struct UpdateEmailRequest {
+    /// The email address.
     #[serde(rename = "email")]
     pub email: String,
 
+    /// Whether to require email authentication.
     #[serde(rename = "emailAuthFactor", default)]
     pub email_auth_factor: bool,
 

--- a/atprotolib-rs/src/types/com_atproto/sync/api_calls.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/api_calls.rs
@@ -10,6 +10,14 @@ use crate::{
     }
 };
 
+/// Get a blob associated with a given account. Returns the full blob as originally uploaded. Does not require auth; implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the account.
+/// * `cid` - The CID of the blob to get.
 pub async fn get_blob(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -38,6 +46,13 @@ pub async fn get_blob(
     }
 }
 
+/// Get the current commit CID & revision of the specified repo. Does not require auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the repo.
 pub async fn get_latest_commit(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -68,6 +83,15 @@ pub async fn get_latest_commit(
     }
 }
 
+/// Get data blocks needed to prove the existence or non-existence of record in the current version of repo. Does not require auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the repo.
+/// * `collection` - The collection of the record.
+/// * `rkey` - The rkey of the record.
 pub async fn get_record(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -97,6 +121,13 @@ pub async fn get_record(
     }
 }
 
+/// Get the hosting status for a repository, on this server. Expected to be implemented by PDS and Relay.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the repo.
 pub async fn get_repo_status(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -124,6 +155,14 @@ pub async fn get_repo_status(
     }
 }
 
+/// Download a repository export as CAR file. Optionally only a 'diff' since a previous revision. Does not require auth; implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the repo.
+/// * `since` - The CID of the previous revision to diff against.
 pub async fn get_repo(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -157,6 +196,16 @@ pub async fn get_repo(
     }
 }
 
+/// List blob CIDs for an account, since some repo revision. Does not require auth; implemented by PDS.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `did` - The DID of the account.
+/// * `since` - The CID of the previous revision to diff against.
+/// * `limit` - The maximum number of blobs to return.
+/// * `cursor` - The cursor to use for pagination.
 pub async fn list_blobs(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -197,6 +246,14 @@ pub async fn list_blobs(
     }
 }
 
+/// Enumerates all the DID, rev, and commit CID for all repos hosted by this service. Does not require auth; implemented by PDS and Relay.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `limit` - The maximum number of repos to return.
+/// * `cursor` - The cursor to use for pagination.
 pub async fn list_repos(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -230,6 +287,13 @@ pub async fn list_repos(
     }
 }
 
+/// Notify a crawling service of a recent update, and that crawling should resume. Intended use is after a gap between repo stream events caused the crawling service to disconnect. Does not require auth; implemented by Relay.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `request` - The request to send.
 pub async fn notify_of_update(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,
@@ -252,6 +316,13 @@ pub async fn notify_of_update(
     }
 }
 
+/// Request a service to persistently crawl hosted repos. Expected use is new PDS instances declaring their existence to Relays. Does not require auth.
+/// 
+/// ## Arguments
+/// 
+/// * `host_name` - The host name of the server to send the request to.
+/// * `api_auth_config` - The authentication configuration to use for the request.
+/// * `request` - The request to send.
 pub async fn request_crawl(
     host_name: &str,
     api_auth_config: &ApiAuthConfig,

--- a/atprotolib-rs/src/types/com_atproto/sync/get_head.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/get_head.rs
@@ -4,13 +4,7 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.getHead
 */
 
-/*    Type: response
-    Id: com.atproto.sync.getHead#response
-    Kind: object
-
-    Properties:
-    - root: string (JsonProperty: root) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetHeadResponse {
     #[serde(rename = "root")]

--- a/atprotolib-rs/src/types/com_atproto/sync/get_latest_commit.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/get_latest_commit.rs
@@ -4,18 +4,14 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.getLatestCommit
 */
 
-/*    Type: response
-    Id: com.atproto.sync.getLatestCommit#response
-    Kind: object
-
-    Properties:
-    - cid: string (JsonProperty: cid) [Required]
-    - rev: string (JsonProperty: rev) [Required]
-*/
+/// Represents a response to a request to get the latest commit.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetLatestCommitResponse {
+    /// The CID of the latest commit.
     #[serde(rename = "cid")]
     pub cid: String,
+
+    /// The revision of the latest commit.
     #[serde(rename = "rev")]
     pub rev: String
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/get_repo_status.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/get_repo_status.rs
@@ -4,24 +4,22 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.getRepoStatus
 */
 
-/*    Type: response
-    Id: com.atproto.sync.getRepoStatus#response
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - active: boolean  (JsonProperty: active) [Required]
-    - status: string (JsonProperty: status) [Optional]
-    - rev: string (JsonProperty: rev) [Optional]
-*/
+/// Represents a response to a request to get the status of a repository.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetRepoStatusResponse {
+    /// The DID of the repository.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// Whether the repository is active.
     #[serde(rename = "active", default)]
     pub active: bool,
+
+    /// The status of the repository.
     #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+
+    /// The latest revision of the repository.
     #[serde(rename = "rev", skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/list_blobs.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/list_blobs.rs
@@ -4,18 +4,14 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.listBlobs
 */
 
-/*    Type: response
-    Id: com.atproto.sync.listBlobs#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - cids: string[] (JsonProperty: cids) [Required]
-*/
+/// Represents a response to a request to list blobs.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListBlobsResponse {
+    /// The cursor stream position.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// The CIDs of the blobs.
     #[serde(rename = "cids")]
     pub cids: Vec<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/list_repos.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/list_repos.rs
@@ -4,43 +4,38 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.listRepos
 */
 
-/*    Type: response
-    Id: com.atproto.sync.listRepos#response
-    Kind: object
-
-    Properties:
-    - cursor: string (JsonProperty: cursor) [Optional]
-    - repos: #repo[] (JsonProperty: repos) [Required]
-*/
+/// Represents a response to a request to list repos.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListReposResponse {
+    /// The cursor stream position.
     #[serde(rename = "cursor", skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+
+    /// The repositories.
     #[serde(rename = "repos")]
     pub repos: Vec<Repo>
 }
 
-/*    Type: repo
-    Id: com.atproto.sync.listRepos#repo
-    Kind: object
-
-    Properties:
-    - did: string (JsonProperty: did) [Required]
-    - head: string (JsonProperty: head) [Required]
-    - rev: string (JsonProperty: rev) [Required]
-    - active: boolean  (JsonProperty: active) [Optional]
-    - status: string (JsonProperty: status) [Optional]
-*/
+/// Represents a repository.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Repo {
+    /// The DID of the repository.
     #[serde(rename = "did")]
     pub did: String,
+
+    /// The head of the repository.
     #[serde(rename = "head")]
     pub head: String,
+
+    /// The latest revision of the repository.
     #[serde(rename = "rev")]
     pub rev: String,
+
+    /// Whether the repository is active.
     #[serde(rename = "active", default)]
     pub active: bool,
+
+    /// The status of the repository.
     #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
     pub status: Option<String>
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/notify_of_update.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/notify_of_update.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.notifyOfUpdate
 */
 
-/*    Type: request
-    Id: com.atproto.sync.notifyOfUpdate#request
-    Kind: object
-
-    Properties:
-    - hostname: string (JsonProperty: hostname) [Required]
-*/
+/// Represents a request to notify of an update.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NotifyOfUpdateRequest {
+    /// The hostname of the server.
     #[serde(rename = "hostname")]
     pub hostname: String
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/request_crawl.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/request_crawl.rs
@@ -4,15 +4,10 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.requestCrawl
 */
 
-/*    Type: request
-    Id: com.atproto.sync.requestCrawl#request
-    Kind: object
-
-    Properties:
-    - hostname: string (JsonProperty: hostname) [Required]
-*/
+/// Represents a request to crawl a hostname.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RequestCrawlRequest {
+    /// The hostname to crawl.
     #[serde(rename = "hostname")]
     pub hostname: String
 }

--- a/atprotolib-rs/src/types/com_atproto/sync/subscribe_repos.rs
+++ b/atprotolib-rs/src/types/com_atproto/sync/subscribe_repos.rs
@@ -5,24 +5,7 @@ use serde::{Deserialize, Serialize};
     com.atproto.sync.subscribeRepos
 */
 
-/*    Type: commit
-    Id: com.atproto.sync.subscribeRepos#commit
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - rebase: boolean  (JsonProperty: rebase) [Required]
-    - too_big: boolean  (JsonProperty: tooBig) [Required]
-    - repo: string (JsonProperty: repo) [Required]
-    - commit: cid-link  (JsonProperty: commit) [Required]
-    - prev: cid-link  (JsonProperty: prev) [Optional]
-    - rev: string (JsonProperty: rev) [Required]
-    - since: string (JsonProperty: since) [Required]
-    - blocks: bytes  (JsonProperty: blocks) [Required]
-    - ops: #repoOp[] (JsonProperty: ops) [Required]
-    - blobs: cid-link[] (JsonProperty: blobs) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Commit {
     #[serde(rename = "seq", default)]
@@ -51,16 +34,7 @@ pub struct Commit {
     pub time: String
 }
 
-/*    Type: identity
-    Id: com.atproto.sync.subscribeRepos#identity
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-    - handle: string (JsonProperty: handle) [Optional]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Identity {
     #[serde(rename = "seq", default)]
@@ -73,17 +47,7 @@ pub struct Identity {
     pub handle: Option<String>
 }
 
-/*    Type: account
-    Id: com.atproto.sync.subscribeRepos#account
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-    - active: boolean  (JsonProperty: active) [Required]
-    - status: string (JsonProperty: status) [Optional]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Account {
     #[serde(rename = "seq", default)]
@@ -98,16 +62,7 @@ pub struct Account {
     pub status: Option<String>
 }
 
-/*    Type: handle
-    Id: com.atproto.sync.subscribeRepos#handle
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - handle: string (JsonProperty: handle) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Handle {
     #[serde(rename = "seq", default)]
@@ -120,16 +75,7 @@ pub struct Handle {
     pub time: DateTime<Utc>
 }
 
-/*    Type: migrate
-    Id: com.atproto.sync.subscribeRepos#migrate
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - migrate_to: string (JsonProperty: migrateTo) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Migrate {
     #[serde(rename = "seq", default)]
@@ -142,15 +88,7 @@ pub struct Migrate {
     pub time: DateTime<Utc>
 }
 
-/*    Type: tombstone
-    Id: com.atproto.sync.subscribeRepos#tombstone
-    Kind: object
-
-    Properties:
-    - seq: integer  (JsonProperty: seq) [Required]
-    - did: string (JsonProperty: did) [Required]
-    - time: datetime (JsonProperty: time) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Tombstone {
     #[serde(rename = "seq", default)]
@@ -161,14 +99,7 @@ pub struct Tombstone {
     pub time: DateTime<Utc>
 }
 
-/*    Type: info
-    Id: com.atproto.sync.subscribeRepos#info
-    Kind: object
-
-    Properties:
-    - name: string (JsonProperty: name) [Required]
-    - message: string (JsonProperty: message) [Optional]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Info {
     #[serde(rename = "name")]
@@ -177,15 +108,7 @@ pub struct Info {
     pub message: Option<String>
 }
 
-/*    Type: repoOp
-    Id: com.atproto.sync.subscribeRepos#repoOp
-    Kind: object
-
-    Properties:
-    - action: string (JsonProperty: action) [Required]
-    - path: string (JsonProperty: path) [Required]
-    - cid: cid-link  (JsonProperty: cid) [Required]
-*/
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RepoOp {
     #[serde(rename = "action")]

--- a/atprotolib-rs/src/types/mod.rs
+++ b/atprotolib-rs/src/types/mod.rs
@@ -1,2 +1,5 @@
+/// API types in the `app.bsky` namespace.
 pub mod app_bsky;
+
+/// API types in the `com.atproto` namespace.
 pub mod com_atproto;


### PR DESCRIPTION
## Description

This is PR adds code docs for the majority of types and functions exposed in the library. Not all have been documented, but I have hit as much as I could and gave them descriptions that I could best come up with. Not all ATProtocol Lexicon definitions are properly documented, so that's what I'm working with.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#1 :point\_left:
